### PR TITLE
Issue/create porto labels template

### DIFF
--- a/Porto-Labels/Template-data.json
+++ b/Porto-Labels/Template-data.json
@@ -1,0 +1,4 @@
+{
+    "LabelColor": "badge badge-default",
+    "LabelSize": "badge"   
+}

--- a/Porto-Labels/Template.hbs
+++ b/Porto-Labels/Template.hbs
@@ -1,0 +1,3 @@
+<span class="{{Settings.LabelSize}} {{Settings.LabelColor}}">{{Label}}</span>
+
+

--- a/Porto-Labels/builder.json
+++ b/Porto-Labels/builder.json
@@ -1,0 +1,17 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Label",
+      "title": "Label Text (required)",
+      "fieldtype": "wysihtml",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    }   
+  ],
+  "formtype": "object"
+}

--- a/Porto-Labels/data.json
+++ b/Porto-Labels/data.json
@@ -1,0 +1,3 @@
+{
+  "Label": "This is my default DNN Label"  
+}

--- a/Porto-Labels/options.json
+++ b/Porto-Labels/options.json
@@ -1,0 +1,7 @@
+{
+  "fields": {
+    "Label": {
+      "type": "wysihtml"
+    }    
+  }
+}

--- a/Porto-Labels/schema.json
+++ b/Porto-Labels/schema.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "Label": {
+      "type": "string",
+      "title": "Label Text (required)",
+      "required": true
+    }    
+  }
+}

--- a/Porto-Labels/template-options.json
+++ b/Porto-Labels/template-options.json
@@ -1,0 +1,31 @@
+{
+	"fields": {		
+		"LabelColor": {
+			"title": "Label Color",
+			"type": "select",
+			"optionLabels": [
+				"Default",
+				"Success",
+				"Info",
+				"Warning",
+				"Danger",
+				"Dark",
+				"Primary",
+				"Secondary",
+				"Tertiary",
+				"Quaternary"
+			],
+			"removeDefaultNone": true
+		},		
+		"LabelSize": {
+			"title": "Label Size",
+			"type": "select",
+			"optionLabels": [
+				"Small",
+				"Default",
+				"Large"			
+			],
+			"removeDefaultNone": true			
+		}
+	}
+}

--- a/Porto-Labels/template-schema.json
+++ b/Porto-Labels/template-schema.json
@@ -1,0 +1,30 @@
+{
+    "type": "object",
+    "properties": {        
+        "LabelColor": {
+            "title": "Label Color",
+            "type": "string",
+            "enum": [
+				"badge badge-default",
+				"badge badge-success",
+				"badge badge-info",
+				"badge badge-warning",
+				"badge badge-danger",
+				"badge badge-dark",
+				"badge badge-primary",
+				"badge badge-secondary",
+				"badge badge-tertiary",
+				"badge badge-quaternary"
+            ]
+        },
+        "LabelSize": {
+            "title": "Label Size",
+            "type": "string",
+            "enum": [
+				"badge badge-sm",
+				"badge",
+				"badge badge-lg"				
+            ]
+        }      
+    }
+}


### PR DESCRIPTION
Adding the OpenContent template for [Porto Labels short code](https://porto.mandeeps.com/shortcodes/shortcodes-2/labels)

##Test performed
![Label](https://user-images.githubusercontent.com/34067433/211738880-498b1271-932d-4202-bce5-effffbec3ce8.jpg)
