### PR TITLE
Issue/create porto labels of type headings template

### DIFF
--- a/Porto-Labels-Headings/Template-data.json
+++ b/Porto-Labels-Headings/Template-data.json
@@ -1,0 +1,4 @@
+{
+    "SubHeadingColor": "badge badge-default",
+    "SubHeadingSize": "h1"    
+}

--- a/Porto-Labels-Headings/Template.hbs
+++ b/Porto-Labels-Headings/Template.hbs
@@ -1,0 +1,4 @@
+
+<{{Settings.SubHeadingSize}}  class="">{{Heading}} <span class="{{Settings.SubHeadingColor}}"> {{SubHeading}}</span> </{{Settings.SubHeadingSize}}>
+
+

--- a/Porto-Labels-Headings/builder.json
+++ b/Porto-Labels-Headings/builder.json
@@ -1,0 +1,23 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Heading",
+      "title": "Heading Text (required)",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "SubHeading",
+      "title": "SubHeading",
+      "fieldtype": "text",
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Labels-Headings/data.json
+++ b/Porto-Labels-Headings/data.json
@@ -1,0 +1,4 @@
+{
+  "Heading": "Example heading",
+  "SubHeading": "New"
+}

--- a/Porto-Labels-Headings/options.json
+++ b/Porto-Labels-Headings/options.json
@@ -1,0 +1,10 @@
+{
+  "fields": {
+    "Heading": {
+      "type": "text"
+    },
+    "SubHeading": {
+      "type": "text"
+    }
+  }
+}

--- a/Porto-Labels-Headings/schema.json
+++ b/Porto-Labels-Headings/schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "Heading": {
+      "position": "2col2",
+      "type": "string",
+      "title": "Heading Text (required)",
+      "required": true
+    },
+    "SubHeading": {
+      "type": "string",
+      "title": "SubHeading",
+      "required": true
+    }
+  }
+}

--- a/Porto-Labels-Headings/template-options.json
+++ b/Porto-Labels-Headings/template-options.json
@@ -1,0 +1,35 @@
+{
+	"fields": {		
+		"SubHeadingColor": {
+			"title": "SubHeading Color",
+			"type": "select",
+			"optionLabels": [
+				"Default",
+				"Success",
+				"Info",
+				"Warning",
+				"Danger",
+				"Dark",
+				"Primary",
+				"Secondary",
+				"Tertiary",
+				"Quaternary"
+			],
+			"removeDefaultNone": true
+		},		
+		"SubHeadingSize": {
+			"title": "SubHeading Size",
+			"type": "select",
+			"optionLabels": [
+				"h1",
+				"h2",
+				"h3",
+				"h4",
+				"h5",
+				"h6"		
+			],
+			"removeDefaultNone": true			
+		}
+
+	}
+}

--- a/Porto-Labels-Headings/template-schema.json
+++ b/Porto-Labels-Headings/template-schema.json
@@ -1,0 +1,33 @@
+{
+    "type": "object",
+    "properties": {        
+        "SubHeadingColor": {
+            "title": "SubHeading Color",
+            "type": "string",
+            "enum": [
+				"badge badge-default",
+				"badge badge-success",
+				"badge badge-info",
+				"badge badge-warning",
+				"badge badge-danger",
+				"badge badge-dark",
+				"badge badge-primary",
+				"badge badge-secondary",
+				"badge badge-tertiary",
+				"badge badge-quaternary"
+            ]
+        },
+        "SubHeadingSize": {
+            "title": "SubHeading Size",
+            "type": "string",
+            "enum": [
+				"h1",
+                "h2",
+                "h3",
+                "h4",
+                "h5",
+                "h6"   			
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Adding the OpenContent template for [Porto Labels of type Headings short code](https://porto.mandeeps.com/shortcodes/shortcodes-2/labels)

##Test performed
![Label-Headings](https://user-images.githubusercontent.com/34067433/211739007-7f471d50-06f7-4f23-9a56-76ea062ef5a6.jpg)
