### PR TITLE
Create porto popover template

### DIFF
--- a/Porto-Popover/Template-data.json
+++ b/Porto-Popover/Template-data.json
@@ -1,0 +1,3 @@
+{
+    "ButtonColor": "btn-primary"
+}

--- a/Porto-Popover/Template.hbs
+++ b/Porto-Popover/Template.hbs
@@ -1,0 +1,1 @@
+<a data-plugin-options="{'placement': 'right'}" tabindex="0" class="btn {{Settings.ButtonColor}} mb-lg" role="button" data-plugin-popover="popover" data-toggle="popover" data-trigger="focus" title="{{PopoverTitle}}" data-content="{{PopoverContent}}">{{Button}}</a>

--- a/Porto-Popover/builder.json
+++ b/Porto-Popover/builder.json
@@ -1,0 +1,28 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Button",
+      "title": "Button Text (required)",
+      "fieldtype": "text",
+      "advanced": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "PopoverTitle",
+      "title": "Popover Title (optional)",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "PopoverContent",
+      "title": "Popover Content (optional)",
+      "fieldtype": "text",
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Popover/data.json
+++ b/Porto-Popover/data.json
@@ -1,0 +1,5 @@
+{
+  "Button": "Show Popover",
+  "PopoverTitle": "Lorem ipsum dolor sit amet.",
+  "PopoverContent": "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+}

--- a/Porto-Popover/options.json
+++ b/Porto-Popover/options.json
@@ -1,0 +1,13 @@
+{
+  "fields": {
+    "Button": {
+      "type": "text"
+    },
+    "PopoverTitle": {
+      "type": "text"
+    },
+    "PopoverContent": {
+      "type": "text"
+    }
+  }
+}

--- a/Porto-Popover/schema.json
+++ b/Porto-Popover/schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "Button": {
+      "type": "string",
+      "title": "Button Text (optional)",
+      "required": false
+    },
+    "PopoverTitle": {
+      "type": "string",
+      "title": "Popover Title (optional)"
+    },
+    "PopoverContent": {
+      "type": "string",
+      "title": "Popover Content (optional)"
+    }
+  }
+}

--- a/Porto-Popover/template-options.json
+++ b/Porto-Popover/template-options.json
@@ -1,0 +1,21 @@
+{
+	"fields": {		
+		"ButtonColor": {
+			"title": "Button Color",
+			"type": "select",
+			"optionLabels": [
+				"Default",
+				"Success",
+				"Info",
+				"Warning",
+				"Danger",
+				"Dark",
+				"Primary",
+				"Secondary",
+				"Tertiary",
+				"Quaternary"
+			],
+			"removeDefaultNone": true
+		}	
+	}
+}

--- a/Porto-Popover/template-schema.json
+++ b/Porto-Popover/template-schema.json
@@ -1,0 +1,21 @@
+{
+    "type": "object",
+    "properties": {        
+        "ButtonColor": {
+            "title": "Button Color",
+            "type": "string",
+            "enum": [
+				"btn-default",
+				"btn-success",
+				"btn-info",
+				"btn-warning",
+				"btn-danger",
+				"btn-dark",
+				"btn-primary",
+				"btn-secondary",
+				"btn-tertiary",
+				"btn-quaternary"
+            ]
+        }
+    }    
+}


### PR DESCRIPTION
Adding the OpenContent template for [Porto Popover short code](https://porto.mandeeps.com/shortcodes/shortcodes-3/tooltips-popovers)

![image](https://user-images.githubusercontent.com/28063771/212468617-80b56f31-179a-4023-bcc7-473e31ad1d9e.png)
