### PR TITLE
Adding the OpenContent Templates for Porto Lightboxes  Shortcodes

### DIFF
--- a/Porto-Lightboxes/Template-data.json
+++ b/Porto-Lightboxes/Template-data.json
@@ -1,0 +1,7 @@
+{
+  "SHOW": "Image-Gallery",
+  "DEFAULT_WITH_BORDER": true,
+  "WITH_ICON": true,
+  "HOVER_EFFECT": true,
+  "ZOOM": true
+}

--- a/Porto-Lightboxes/Template.hbs
+++ b/Porto-Lightboxes/Template.hbs
@@ -1,0 +1,47 @@
+{{#equal Settings.SHOW "Single-Image"}}
+<div class="row">
+  <div class="col-md-3">
+    <a
+      class="{{#if Settings.DEFAULT_WITH_BORDER}} img-thumbnail {{/if}} {{#if Settings.HOVER_EFFECT}} img-thumbnail-hover-icon {{/if}} lightbox d-block"
+      href="{{SingleImage}}"
+      data-plugin-options="{'type':'image'}"
+    >
+      <img class="img-fluid" src="{{SingleImage}}" alt="Project Image" />
+      {{#if Settings.WITH_ICON}}
+      <span class="zoom"><em class="fas fa-search"></em></span>
+      {{/if}}
+      <span class="btn-text-indent">Lightbox</span>
+    </a>
+  </div>
+</div>
+{{/equal}}
+{{#equal Settings.SHOW "Image-Gallery"}}
+<div class="lightbox" data-plugin-options="{'delegate': 'a', 'type': 'image', 'gallery': {'enabled': true}, 'mainClass': 'mfp-with-zoom', 'zoom': {{#if ../Settings.ZOOM}} {'enabled': true, 'duration': 300} {{else}} {'enabled': false, 'duration': 300} {{/if}} }">
+	{{#each ImageGallery}}
+  <a class="{{#if ../Settings.DEFAULT_WITH_BORDER}} img-thumbnail {{/if}} {{#if ../Settings.HOVER_EFFECT}} img-thumbnail-hover-icon {{/if}} d-inline-block mb-xs mr-xs" href="{{Image}}">
+		<img class="img-fluid" src="{{Image}}" alt="Project Image" width="110" height="110" />
+     {{#if ../Settings.WITH_ICON}}
+      <span class="zoom"><em class="fas fa-search"></em></span>
+      {{/if}}
+		<span class="btn-text-indent">Lightbox</span>
+	</a>
+  {{/each}}
+</div>
+{{/equal}}
+{{#equal Settings.SHOW "Image-GalleryCarousel"}}
+<div class="lightbox" data-plugin-options="{'delegate': 'a', 'type': 'image', 'gallery': {'enabled': true}, 'mainClass': 'mfp-with-zoom', 'zoom': {{#if ../Settings.ZOOM}} {'enabled': true, 'duration': 300} {{else}} {'enabled': false, 'duration': 300} {{/if}} }">
+<div class="owl-carousel stage-margin" data-plugin-options="{'items': 6, 'margin': 10, 'loop': false, 'nav': true, 'dots': false, 'stagePadding': 40}">
+	{{#each ImageGallery}}
+  <div>
+  <a class="{{#if ../Settings.DEFAULT_WITH_BORDER}} img-thumbnail {{/if}} {{#if ../Settings.HOVER_EFFECT}} img-thumbnail-hover-icon {{/if}} d-inline-block mb-xs mr-xs" href="{{Image}}">
+		<img class="img-fluid" src="{{Image}}" alt="Project Image" width="110" height="110" />
+     {{#if ../Settings.WITH_ICON}}
+      <span class="zoom"><em class="fas fa-search"></em></span>
+      {{/if}}
+		<span class="btn-text-indent">Lightbox</span>
+	</a>
+  </div>
+  {{/each}}
+</div>
+</div>
+{{/equal}}

--- a/Porto-Lightboxes/builder.json
+++ b/Porto-Lightboxes/builder.json
@@ -1,0 +1,27 @@
+{
+  "formfields": [
+    {
+      "fieldname": "SingleImage",
+      "title": "Single Image",
+      "fieldtype": "image",
+      "imageoptions": {},
+      "advanced": false
+    },
+    {
+      "fieldname": "ImageGallery",
+      "title": "Image Gallery",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "Image",
+          "title": "Image",
+          "fieldtype": "image",
+          "imageoptions": {},
+          "advanced": false
+        }
+      ],
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Lightboxes/options.fr-FR.json
+++ b/Porto-Lightboxes/options.fr-FR.json
@@ -1,0 +1,18 @@
+{
+	"fields": {
+		"Boxes": {
+			"fields": {
+				"item": {
+					"fields": {
+						"FrontDescription": {
+							"label": "Content au recto"
+						},
+						"BackDescription": {
+							"label": "Content au verso"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/Porto-Lightboxes/options.json
+++ b/Porto-Lightboxes/options.json
@@ -1,0 +1,17 @@
+{
+  "fields": {
+    "SingleImage": {
+      "type": "image"
+    },
+    "ImageGallery": {
+      "type": "array",
+      "items": {
+        "fields": {
+          "Image": {
+            "type": "image"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Lightboxes/schema.json
+++ b/Porto-Lightboxes/schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "SingleImage": {
+      "type": "string",
+      "title": "Single Image"
+    },
+    "ImageGallery": {
+      "type": "array",
+      "title": "Image Gallery",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Image": {
+            "type": "string",
+            "title": "Image"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Lightboxes/template-options.json
+++ b/Porto-Lightboxes/template-options.json
@@ -1,0 +1,30 @@
+{
+  "fields": {
+    "SHOW": {
+      "title": "SHOW",
+      "type": "select",
+      "optionLabels": [
+        "Single Image",
+        "Image Gallery",
+        "Image Gallery Carousel"
+      ],
+      "removeDefaultNone": true
+    },
+    "DEFAULT_WITH_BORDER": {
+      "label": "DEFAULT WITH BORDER",
+      "type": "checkbox"
+    },
+    "WITH_ICON": {
+      "label": "WITH ICON",
+      "type": "checkbox"
+    },
+    "HOVER_EFFECT": {
+      "label": "HOVER EFFECT",
+      "type": "checkbox"
+    },
+    "ZOOM": {
+      "label": "ZOOM",
+      "type": "checkbox"
+    }
+  }
+}

--- a/Porto-Lightboxes/template-schema.json
+++ b/Porto-Lightboxes/template-schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "SHOW": {
+      "title": "SHOW",
+      "type": "select",
+      "enum": ["Single-Image", "Image-Gallery", "Image-GalleryCarousel"],
+      "removeDefaultNone": true
+    },
+    "DEFAULT_WITH_BORDER": {
+      "title": "DEFAULT WITH BORDER",
+      "type": "boolean"
+    },
+    "WITH_ICON": {
+      "title": "WITH ICON",
+      "type": "boolean"
+    },
+    "HOVER_EFFECT": {
+      "title": "HOVER EFFECT",
+      "type": "boolean"
+    },
+    "ZOOM": {
+      "title": "ZOOM",
+      "type": "boolean"
+    }
+  }
+}

--- a/Porto-Lightboxes/view.json
+++ b/Porto-Lightboxes/view.json
@@ -1,0 +1,10 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "SingleImage": "#pos_1_1",
+      "ImageGallery": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
I divided Lightboxes Shortcodes into two independent templates by their structure, one for the images
 and another for the dialogs that I started working on and will finish tomorrow.
(https://porto.mandeeps.com/shortcodes/shortcodes-1/lightbox)

![My Website  Porto Templates  Lightboxes - Google Chrome](https://user-images.githubusercontent.com/48692645/213072472-66c93514-90bc-4fa2-b0a4-cc82d8d514b4.jpg)

