### PR TITLE
Adding the OpenContent Templates for Porto Lightboxes-Dialog Shortcodes

### DIFF
--- a/Porto-Lightboxes-Dialog/Template-data.json
+++ b/Porto-Lightboxes-Dialog/Template-data.json
@@ -1,0 +1,5 @@
+{
+  "Style": "Animation",
+  "Animation": "popup-with-move-anim",
+  "Color": "btn-primary"
+}

--- a/Porto-Lightboxes-Dialog/Template.hbs
+++ b/Porto-Lightboxes-Dialog/Template.hbs
@@ -1,0 +1,79 @@
+{{#equal Settings.Style "Animation"}}
+  <a
+    class="mt-xs mb-xs {{Settings.Animation}} btn {{Settings.Color}}"
+    href="#small-dialog"
+  >{{ButtonText}}</a>
+  <div
+    class="dialog dialog-sm {{Settings.Animation}} mfp-hide"
+    id="small-dialog"
+  >
+    <h1>{{DialogTitle}}</h1>
+    <p>{{DialogText}}</p>
+  </div>
+{{/equal}}
+{{#equal Settings.Style "Popup"}}
+  <div class="row">
+    <div class="col-md-4"><a
+        class="mt-xs mb-xs mr-xs {{Settings.Popup}} btn {{Settings.Color}}"
+        href="{{href}}"
+      >{{ButtonText}}</a>
+    </div>
+  </div>
+{{/equal}}
+
+{{#equal Settings.Style "Form"}}
+  <a class="popup-with-form btn {{Settings.Color}}" href="#demo-form">{{ButtonText}}</a>
+  <div id="demo-form" class="white-popup-block mfp-hide form-horizontal">
+    <div class="row">
+      <div class="col-sm-12">
+        <h4>{{FormTitle}}</h4>
+        <p class="mb-lg">{{FormSubTitle}}</p>
+      </div>
+    </div>
+    <div class="form-group mt-lg">
+      <div class="row">
+        {{#each FormData}}
+          {{#equal FormDataType "textarea"}}
+            <div class="{{GridWidth}}">
+              <label
+                for="{{InputText}}"
+                class="control-label"
+              >{{InputText}}</label>
+              <textarea
+                rows="{{Row}}"
+                type="{{FormDataType}}"
+                id="{{InputText}}"
+                name="{{InputText}}"
+                class="form-control"
+                placeholder="Type your {{InputText}}..."
+              ></textarea>
+            </div>
+            {{else}}
+            <div class="{{GridWidth}}">
+              <label
+                for="{{InputText}}"
+                class="control-label"
+              >{{InputText}}</label>
+              <input
+                type="{{FormDataType}}"
+                id="{{InputText}}"
+                name="{{InputText}}"
+                class="form-control"
+                placeholder="Type your {{InputText}}..."
+              ></input>
+            </div>
+          {{/equal}}
+        {{/each}}
+      </div>
+    </div>
+    <div class="row mb-lg">
+      <div class="col-sm-12">
+        <button class="btn {{ColorFormButton1}}">{{FormButtonText1}}</button>
+        <button
+          type="reset"
+          class="btn {{ColorFormButton2}}"
+        >{{FormButtonText2}}</button>
+      </div>
+    </div>
+  </div>
+{{/equal}}

--- a/Porto-Lightboxes-Dialog/builder.json
+++ b/Porto-Lightboxes-Dialog/builder.json
@@ -1,0 +1,273 @@
+{
+  "formfields": [
+    {
+      "fieldname": "ButtonText",
+      "title": "Button Text",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "DialogTitle",
+      "title": "Dialog Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "DialogText",
+      "title": "Dialog Text",
+      "fieldtype": "textarea",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "href",
+      "title": "href",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "FormTitle",
+      "title": "Form Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "FormSubTitle",
+      "title": "Form Sub Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "FormData",
+      "title": "FormData",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "InputText",
+          "title": "InputText",
+          "fieldtype": "text",
+          "advanced": false
+        },
+        {
+          "fieldname": "FormDataType",
+          "title": "FormDataType",
+          "fieldtype": "select",
+          "fieldoptions": [
+            {
+              "value": "text",
+              "text": "text"
+            },
+            {
+              "value": "email",
+              "text": "email"
+            },
+            {
+              "value": "url",
+              "text": "url"
+            },
+            {
+              "value": "textarea",
+              "text": "textarea"
+            }
+          ],
+          "advanced": false
+        },
+        {
+          "fieldname": "Row",
+          "title": "Row",
+          "fieldtype": "select",
+          "advanced": true,
+          "required": false,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": [
+            {
+              "fieldname": "FormDataType",
+              "values": "textarea"
+            }
+          ],
+          "fieldoptions": [
+            {
+              "value": "col-md-12",
+              "text": "col-md-12"
+            },
+            {
+              "value": "col-md-11",
+              "text": "col-md-11"
+            },
+            {
+              "value": "col-md-10",
+              "text": "col-md-10"
+            },
+            {
+              "value": "col-md-9",
+              "text": "col-md-9"
+            },
+            {
+              "value": "col-md-8",
+              "text": "col-md-8"
+            },
+            {
+              "value": "col-md-7",
+              "text": "col-md-7"
+            },
+            {
+              "value": "col-md-6",
+              "text": "col-md-6"
+            },
+            {
+              "value": "col-md-5",
+              "text": "col-md-5"
+            },
+            {
+              "value": "col-md-4",
+              "text": "col-md-4"
+            },
+            {
+              "value": "col-md-3",
+              "text": "col-md-3"
+            },
+            {
+              "value": "col-md-2",
+              "text": "col-md-2"
+            },
+            {
+              "value": "col-md-1",
+              "text": "col-md-1"
+            }
+          ]
+        },
+        {
+          "fieldname": "GridWidth",
+          "title": "GridWidth",
+          "fieldtype": "select",
+          "fieldoptions": [
+            {
+              "value": "col-md-12",
+              "text": "col-md-12"
+            },
+            {
+              "value": "col-md-11",
+              "text": "col-md-11"
+            },
+            {
+              "value": "col-md-10",
+              "text": "col-md-10"
+            },
+            {
+              "value": "col-md-9",
+              "text": "col-md-9"
+            },
+            {
+              "value": "col-md-8",
+              "text": "col-md-8"
+            },
+            {
+              "value": "col-md-7",
+              "text": "col-md-7"
+            },
+            {
+              "value": "col-md-6",
+              "text": "col-md-6"
+            },
+            {
+              "value": "col-md-5",
+              "text": "col-md-5"
+            },
+            {
+              "value": "col-md-4",
+              "text": "col-md-4"
+            },
+            {
+              "value": "col-md-3",
+              "text": "col-md-3"
+            },
+            {
+              "value": "col-md-2",
+              "text": "col-md-2"
+            },
+            {
+              "value": "col-md-1",
+              "text": "col-md-1"
+            }
+          ],
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        }
+      ],
+      "advanced": false
+    },
+    {
+      "fieldname": "FormButtonText1",
+      "title": "FormButtonText1",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "FormButtonText2",
+      "title": "FormButtonText2",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ColorFormButton1",
+      "title": "ColorFormButton1",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "btn-primary",
+          "text": "primary"
+        },
+        {
+          "value": "btn-secondary",
+          "text": "secondary"
+        },
+        {
+          "value": "btn-tertiary",
+          "text": "tertiary"
+        },
+        {
+          "value": "btn-quaternary",
+          "text": "quaternary"
+        }
+      ],
+      "advanced": false
+    },
+    {
+      "fieldname": "ColorFormButton2",
+      "title": "ColorFormButton2",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "btn-primary",
+          "text": "primary"
+        },
+        {
+          "value": "btn-secondary",
+          "text": "secondary"
+        },
+        {
+          "value": "btn-tertiary",
+          "text": "tertiary"
+        },
+        {
+          "value": "btn-quaternary",
+          "text": "quaternary"
+        }
+      ],
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Lightboxes-Dialog/data.json
+++ b/Porto-Lightboxes-Dialog/data.json
@@ -1,0 +1,24 @@
+{
+  "ButtonText": "Open Dialog",
+  "DialogTitle": "Some Title Here",
+  "DialogText": "Some text Here",
+  "href": "http://www.youtube.com/watch?v=0O2aH4XLbto",
+  "FormTitle": "Form Title Here",
+  "FormSubTitle": "Form Subtitle Here",
+  "FormData": [
+    {
+      "InputText": "name",
+      "FormDataType": "text",
+      "GridWidth": "col-md-6"
+    },
+    {
+      "InputText": "email",
+      "FormDataType": "email",
+      "GridWidth": "col-md-6"
+    }
+  ],
+  "FormButtonText1": "Submit",
+  "FormButtonText2": "Reset",
+  "ColorFormButton1": "btn-primary",
+  "ColorFormButton2": "btn-quaternary"
+}

--- a/Porto-Lightboxes-Dialog/options.fr-FR.json
+++ b/Porto-Lightboxes-Dialog/options.fr-FR.json
@@ -1,0 +1,18 @@
+{
+	"fields": {
+		"Boxes": {
+			"fields": {
+				"item": {
+					"fields": {
+						"FrontDescription": {
+							"label": "Content au recto"
+						},
+						"BackDescription": {
+							"label": "Content au verso"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/Porto-Lightboxes-Dialog/options.json
+++ b/Porto-Lightboxes-Dialog/options.json
@@ -1,0 +1,79 @@
+{
+  "fields": {
+    "ButtonText": {
+      "type": "text"
+    },
+    "DialogTitle": {
+      "type": "text"
+    },
+    "DialogText": {
+      "type": "textarea"
+    },
+    "href": {
+      "type": "text"
+    },
+    "FormTitle": {
+      "type": "text"
+    },
+    "FormSubTitle": {
+      "type": "text"
+    },
+    "FormData": {
+      "type": "array",
+      "items": {
+        "fields": {
+          "InputText": {
+            "type": "text"
+          },
+          "FormDataType": {
+            "type": "select",
+            "sort": false,
+            "optionLabels": ["text", "email", "url", "textarea"]
+          },
+          "Row": {
+            "type": "select",
+            "optionLabels": ["10", "9", "8", "7", "6", "5", "4", "3", "2", "1"],
+            "removeDefaultNone": true,
+            "dependencies": {
+              "FormDataType": ["textarea"]
+            }
+          },
+          "GridWidth": {
+            "type": "select",
+            "sort": false,
+            "optionLabels": [
+              "col-md-12",
+              "col-md-11",
+              "col-md-10",
+              "col-md-9",
+              "col-md-8",
+              "col-md-7",
+              "col-md-6",
+              "col-md-5",
+              "col-md-4",
+              "col-md-3",
+              "col-md-2",
+              "col-md-1"
+            ]
+          }
+        }
+      }
+    },
+    "FormButtonText1": {
+      "type": "text"
+    },
+    "FormButtonText2": {
+      "type": "text"
+    },
+    "ColorFormButton1": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": ["primary", "secondary", "tertiary", "quaternary"]
+    },
+    "ColorFormButton2": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": ["primary", "secondary", "tertiary", "quaternary"]
+    }
+  }
+}

--- a/Porto-Lightboxes-Dialog/schema.json
+++ b/Porto-Lightboxes-Dialog/schema.json
@@ -1,0 +1,94 @@
+{
+  "type": "object",
+  "properties": {
+    "ButtonText": {
+      "type": "string",
+      "title": "Button Text"
+    },
+    "DialogTitle": {
+      "type": "string",
+      "title": "Dialog Title"
+    },
+    "DialogText": {
+      "type": "string",
+      "title": "Dialog Text",
+      "required": true
+    },
+    "href": {
+      "type": "string",
+      "title": "href"
+    },
+    "FormTitle": {
+      "type": "string",
+      "title": "Form Title"
+    },
+    "FormSubTitle": {
+      "type": "string",
+      "title": "Form Sub Title"
+    },
+    "FormData": {
+      "type": "array",
+      "title": "FormData",
+      "items": {
+        "type": "object",
+        "properties": {
+          "InputText": {
+            "type": "string",
+            "title": "InputText"
+          },
+          "FormDataType": {
+            "type": "string",
+            "title": "FormDataType",
+            "enum": ["text", "email", "url", "textarea"]
+          },
+          "Row": {
+            "type": "string",
+            "title": "Row",
+            "enum": ["10", "9", "8", "7", "6", "5", "4", "3", "2", "1"],
+            "removeDefaultNone": true,
+            "default": "5",
+            "dependencies": ["FormDataType"]
+          },
+          "GridWidth": {
+            "type": "string",
+            "title": "GridWidth",
+            "enum": [
+              "col-md-12",
+              "col-md-11",
+              "col-md-10",
+              "col-md-9",
+              "col-md-8",
+              "col-md-7",
+              "col-md-6",
+              "col-md-5",
+              "col-md-4",
+              "col-md-3",
+              "col-md-2",
+              "col-md-1"
+            ],
+            "default": "col-md-12",
+            "required": true
+          }
+        }
+      }
+    },
+    "FormButtonText1": {
+      "type": "string",
+      "title": "FormButtonText1"
+    },
+    "FormButtonText2": {
+      "type": "string",
+      "title": "FormButtonText2"
+    },
+    "ColorFormButton1": {
+      "type": "string",
+      "title": "ColorFormButton1",
+      "enum": ["btn-primary", "btn-secondary", "btn-tertiary", "btn-quaternary"]
+    },
+    "ColorFormButton2": {
+      "type": "string",
+      "title": "ColorFormButton2",
+      "enum": ["btn-primary", "btn-secondary", "btn-tertiary", "btn-quaternary"]
+    }
+  }
+}

--- a/Porto-Lightboxes-Dialog/template-options.json
+++ b/Porto-Lightboxes-Dialog/template-options.json
@@ -1,0 +1,28 @@
+{
+  "fields": {
+    "Style": {
+      "title": "Style",
+      "type": "select",
+      "optionLabels": ["Animation", "Popup", "Form"],
+      "removeDefaultNone": true
+    },
+    "Animation": {
+      "title": "Animation",
+      "type": "select",
+      "optionLabels": ["with zoom anim", "with move anim"],
+      "removeDefaultNone": true
+    },
+    "Popup": {
+      "title": "Popup",
+      "type": "select",
+      "optionLabels": ["youtube", "vimeo", "gmaps"],
+      "removeDefaultNone": true
+    },
+    "Color": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": ["primary", "secondary", "tertiary", "quaternary"],
+      "removeDefaultNone": true
+    }
+  }
+}

--- a/Porto-Lightboxes-Dialog/template-schema.json
+++ b/Porto-Lightboxes-Dialog/template-schema.json
@@ -1,0 +1,34 @@
+{
+  "type": "object",
+  "properties": {
+    "Style": {
+      "title": "Style",
+      "type": "select",
+      "enum": ["Animation", "Popup", "Form"],
+      "removeDefaultNone": true
+    },
+    "Animation": {
+      "title": "Animation",
+      "type": "select",
+      "enum": ["popup-with-zoom-anim", "popup-with-move-anim"],
+      "removeDefaultNone": true
+    },
+    "Popup": {
+      "title": "Popup",
+      "type": "select",
+      "enum": ["popup-youtube", "popup-vimeo", "popup-gmaps"],
+      "removeDefaultNone": true
+    },
+    "Color": {
+      "type": "string",
+      "title": "Color",
+      "enum": [
+        "btn-primary",
+        "btn-secondary",
+        "btn-tertiary",
+        "btn-quaternary"
+      ],
+      "removeDefaultNone": true
+    }
+  }
+}

--- a/Porto-Lightboxes-Dialog/view.json
+++ b/Porto-Lightboxes-Dialog/view.json
@@ -1,0 +1,19 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "ButtonText": "#pos_1_1",
+      "DialogTitle": "#pos_1_1",
+      "DialogText": "#pos_1_1",
+      "href": "#pos_1_1",
+      "FormTitle": "#pos_1_1",
+      "FormSubTitle": "#pos_1_1",
+      "FormData": "#pos_1_1",
+      "FormButtonText1": "#pos_1_1",
+      "FormButtonText2": "#pos_1_1",
+      "ColorFormButton1": "#pos_1_1",
+      "ColorFormButton2": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
An example of test performance

![PrtScr capture](https://user-images.githubusercontent.com/48692645/213315956-b4ef101f-a844-4868-9857-4d4dfb56dbfb.jpg)
