### PR TITLE
Issue/create porto section and parallax template

### DIFF
--- a/Porto-Section-Parallax/Template.hbs
+++ b/Porto-Section-Parallax/Template.hbs
@@ -1,0 +1,82 @@
+{{#equal StyleType "HalfSection"}}
+<div class="container-fluid">
+	<div class="row">
+		<div class="col-md-6 p-none">
+			<section style="background-image: url('{{Image}}');" class="section section-text-light section-background section-center match-height">
+				<div class="container">
+					<div class="row">
+						<div class="col-md-12"> </div>
+					</div>
+				</div>
+			</section>
+		</div>
+		<div class="col-md-6 p-none">
+			<section class="section section-default pl-lg pr-lg match-height">
+				<div class="row">
+					<div class="col-md-12">
+						<h5>{{Heading}}</h5>
+						<p class="mb-none">
+							{{SubHeading}}
+						</p>
+					</div>
+				</div>
+			</section>
+		</div>
+	</div>
+</div>
+{{else}}
+{{#equal StyleType "HalfSectionParallax"}}
+<div class="container-fluid">
+	<div class="row">
+		<div class="col-md-6 p-none">
+			<section class="section section-primary pl-lg pr-lg match-height">
+				<div class="row">
+					<div class="col-md-12">
+						<h5>{{Heading}}</h5>
+						<p class="mb-none"> {{SubHeading}} </p>
+					</div>
+				</div>
+			</section>
+		</div>
+		<div class="col-md-6 p-none">
+			<section class="parallax section section-parallax match-height" data-plugin-parallax="parallax" data-image-src="{{Image}}"></section>
+		</div>
+	</div>
+</div>
+{{else}}
+<section class="
+{{#equal StyleType "Default"}}{{StyleDefault}}{{/equal}} 
+{{#equal StyleType "BackgroundSection"}}{{StyleBackground}}{{/equal}}
+{{#equal StyleType "ParallaxSection"}}{{StyleParallax}}{{/equal}}
+{{#equal StyleType "VideoSection"}}video section section-text-light section-video section-center{{/equal}}" 
+{{#equal StyleType "BackgroundSection"}}style="background-image: url('{{Image}}');"{{/equal}}
+{{#equal StyleType "VideoSection"}}data-plugin-options="{'posterType': 'jpg', 'position': '50% 50%', 'overlay': true}" data-plugin-video-background="{{VideoUrl}}" data-video-path="{{VideoUrl}}"{{/equal}} 
+{{#equal StyleType "ParallaxSection"}}data-image-src="{{Image}}" data-plugin-options="{'speed': 1.5}" data-plugin-parallax="parallax"{{/equal}}>
+{{#equal StyleDefault "section section-default section-with-divider"}}
+    <div class="divider divider-solid divider-style-4">
+		<em class="fas fa-chevron-down"></em>
+	</div>
+{{/equal}}
+	<div class="container">
+		<div class="row">
+            {{#equal StyleType "VideoSection"}}
+            <div class="col-md-8 offset-md-2">
+            {{/equal}}
+            {{#equal StyleType "ParallaxSection"}}
+            <div class="col-md-8 offset-md-2">
+            {{/equal}}
+            {{#equal StyleType "BackgroundSection"}}
+			<div class="col-md-12">
+            {{/equal}}
+            {{#equal StyleType "Default"}}
+			<div class="col-md-12">
+            {{/equal}}
+				<h4 class="mb-none {{#if TextLight}}text-light{{/if}}">{{Heading}}</h4>
+				<p class="mb-none {{#if TextLight}}text-light{{/if}}">{{SubHeading}}</p>
+			</div>
+		</div>
+	</div>
+</section>
+{{/equal}}
+{{/equal}}
+{{/equal}}

--- a/Porto-Section-Parallax/builder.json
+++ b/Porto-Section-Parallax/builder.json
@@ -1,0 +1,238 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Heading",
+      "title": "Heading Text (required)",
+      "fieldtype": "wysihtml",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "SubHeading",
+      "title": "Heading Subtitle",
+      "fieldtype": "wysihtml",
+      "advanced": false
+    },
+    {
+      "fieldname": "TextLight",
+      "title": "Text-Light",
+      "fieldtype": "checkbox",
+      "advanced": false
+    },
+    {
+      "fieldname": "StyleType",
+      "title": "Style Type",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "Default",
+          "text": "Default Section"
+        },
+        {
+          "value": "BackgroundSection",
+          "text": "Background Section"
+        },
+        {
+          "value": "ParallaxSection",
+          "text": "Parallax Section"
+        },
+        {
+          "value": "HalfSection",
+          "text": "Half Section (With Custom Background)"
+        },
+        {
+          "value": "HalfSectionParallax",
+          "text": "Half Section (With Parallax)"
+        },
+        {
+          "value": "VideoSection",
+          "text": "Video Section"
+        }
+      ],
+      "advanced": false
+    },
+    {
+      "fieldname": "StyleDefault",
+      "title": "Style Default",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "section section-default",
+          "text": "Default Section"
+        },
+        {
+          "value": "section section-default section-default-scale-1",
+          "text": "Color Scale 1 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-2",
+          "text": "Color Scale 2 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-3",
+          "text": "Color Scale 3 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-4",
+          "text": "Color Scale 4 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-5",
+          "text": "Color Scale 5 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-6",
+          "text": "Color Scale 6 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-7",
+          "text": "Color Scale 7 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-8",
+          "text": "Color Scale 8 Section"
+        },
+        {
+          "value": "section section-default section-default-scale-9",
+          "text": "Color Scale 9 Section"
+        },
+        {
+          "value": "section section-primary",
+          "text": "Primary Section"
+        },
+        {
+          "value": "section section-secondary",
+          "text": "Secondary Section"
+        },
+        {
+          "value": "section section-tertiary",
+          "text": "Tertiary Section"
+        },
+        {
+          "value": "section section-quaternary",
+          "text": "Quaternary Section"
+        },
+        {
+          "value": "section section-default mt-none mb-none",
+          "text": "Removing Margin Top and Bottom"
+        },
+        {
+          "value": "section section-default section-with-divider",
+          "text": "With Divider"
+        },
+        {
+          "value": "section section-default section-center",
+          "text": "Center-Aligned Content Section"
+        }
+      ],
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "StyleType",
+          "values": "Default"
+        }
+      ]
+    },
+    {
+      "fieldname": "StyleParallax",
+      "title": "Style Parallax",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "section section-text-light section-parallax section-center",
+          "text": "Default Parallax Section"
+        },
+        {
+          "value": "parallax section section-text-light section-parallax section-center",
+          "text": "Parallax Section (Fixed Image)"
+        },
+        {
+          "value": "parallax section section-parallax section-center",
+          "text": "Parallax Section (Dark Text)"
+        }
+      ],
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "StyleType",
+          "values": "ParallaxSection"
+        }
+      ]
+    },
+    {
+      "fieldname": "StyleBackground",
+      "title": "Style Background",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "section section-text-light section-background section-center",
+          "text": "Custom Background Section"
+        },
+        {
+          "value": "section section-text-light section-background section-center section-overlay",
+          "text": "Custom Background Section (With Overlay)"
+        }
+      ],
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "StyleType",
+          "values": "BackgroundSection"
+        }
+      ]
+    },
+    {
+      "fieldname": "Image",
+      "title": "Image",
+      "fieldtype": "image",
+      "imageoptions": {},
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "StyleType",
+          "values": "BackgroundSection,ParallaxSection,HalfSection,HalfSectionParallax"
+        }
+      ]
+    },
+    {
+      "fieldname": "VideoUrl",
+      "title": "Video Url",
+      "fieldtype": "file",
+      "fileoptions": {},
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "StyleType",
+          "values": "VideoSection"
+        }
+      ]
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Section-Parallax/data.json
+++ b/Porto-Section-Parallax/data.json
@@ -1,0 +1,6 @@
+{
+  "Heading": "What is Lorem Ipsum?",
+  "SubHeading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum eros ipsum, facilisis eget scelerisque non, fermentum at tellus.",
+  "StyleType" : "Default",
+  "StyleDefault": "section section-default"
+}

--- a/Porto-Section-Parallax/options.json
+++ b/Porto-Section-Parallax/options.json
@@ -1,0 +1,99 @@
+{
+  "fields": {
+    "Heading": {
+      "type": "wysihtml"
+    },
+    "SubHeading": {
+      "type": "wysihtml"
+    },
+    "TextLight": {
+      "type": "checkbox"
+    },
+    "StyleType": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "Default Section",
+        "Background Section",
+        "Parallax Section",
+        "Half Section (With Custom Background)",
+        "Half Section (With Parallax)",
+        "Video Section"
+      ]
+    },
+    "StyleDefault": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "Default Section",
+        "Color Scale 1 Section",
+        "Color Scale 2 Section",
+        "Color Scale 3 Section",
+        "Color Scale 4 Section",
+        "Color Scale 5 Section",
+        "Color Scale 6 Section",
+        "Color Scale 7 Section",
+        "Color Scale 8 Section",
+        "Color Scale 9 Section",
+        "Primary Section",
+        "Secondary Section",
+        "Tertiary Section",
+        "Quaternary Section",
+        "Removing Margin Top and Bottom",
+        "With Divider",
+        "Center-Aligned Content Section"
+      ],
+      "dependencies": {
+        "StyleType": [
+          "Default"
+        ]
+      }
+    },
+    "StyleParallax": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "Default Parallax Section",
+        "Parallax Section (Fixed Image)",
+        "Parallax Section (Dark Text)"
+      ],
+      "dependencies": {
+        "StyleType": [
+          "ParallaxSection"
+        ]
+      }
+    },
+    "StyleBackground": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "Custom Background Section",
+        "Custom Background Section (With Overlay)"
+      ],
+      "dependencies": {
+        "StyleType": [
+          "BackgroundSection"
+        ]
+      }
+    },
+    "Image": {
+      "type": "image",
+      "dependencies": {
+        "StyleType": [
+          "BackgroundSection",
+          "ParallaxSection",
+          "HalfSection",
+          "HalfSectionParallax"
+        ]
+      }
+    },
+    "VideoUrl": {
+      "type": "file",
+      "dependencies": {
+        "StyleType": [
+          "VideoSection"
+        ]
+      }
+    }
+  }
+}

--- a/Porto-Section-Parallax/schema.json
+++ b/Porto-Section-Parallax/schema.json
@@ -1,0 +1,94 @@
+{
+  "type": "object",
+  "properties": {
+    "Heading": {
+      "type": "string",
+      "title": "Heading Text (required)"
+    },
+    "SubHeading": {
+      "type": "string",
+      "title": "Heading Subtitle"
+    },
+    "TextLight": {
+      "type": "boolean",
+      "title": "Text-Light"
+    },
+    "StyleType": {
+      "type": "string",
+      "title": "Style Type",
+      "enum": [
+        "Default",
+        "BackgroundSection",
+        "ParallaxSection",
+        "HalfSection",
+        "HalfSectionParallax",
+        "VideoSection"
+      ]
+    },
+    "StyleDefault": {
+      "type": "string",
+      "title": "Style Default",
+      "enum": [
+        "section section-default",
+        "section section-default section-default-scale-1",
+        "section section-default section-default-scale-2",
+        "section section-default section-default-scale-3",
+        "section section-default section-default-scale-4",
+        "section section-default section-default-scale-5",
+        "section section-default section-default-scale-6",
+        "section section-default section-default-scale-7",
+        "section section-default section-default-scale-8",
+        "section section-default section-default-scale-9",
+        "section section-primary",
+        "section section-secondary",
+        "section section-tertiary",
+        "section section-quaternary",
+        "section section-default mt-none mb-none",
+        "section section-default section-with-divider",
+        "section section-default section-center"
+      ],
+      "dependencies": [
+        "StyleType"
+      ]
+    },
+    "StyleParallax": {
+      "type": "string",
+      "title": "Style Parallax",
+      "enum": [
+        "section section-text-light section-parallax section-center",
+        "parallax section section-text-light section-parallax section-center",
+        "parallax section section-parallax section-center"
+      ],
+      "dependencies": [
+        "StyleType"
+      ]
+    },
+    "StyleBackground": {
+      "type": "string",
+      "title": "Style Background",
+      "enum": [
+        "section section-text-light section-background section-center",
+        "section section-text-light section-background section-center section-overlay"
+      ],
+      "dependencies": [
+        "StyleType"
+      ]
+    },
+    "Image": {
+      "type": "string",
+      "title": "Image",
+      "required": true,
+      "dependencies": [
+        "StyleType"
+      ]
+    },
+    "VideoUrl": {
+      "type": "string",
+      "title": "Video Url",
+      "required": true,
+      "dependencies": [
+        "StyleType"
+      ]
+    }
+  }
+}

--- a/Porto-Section-Parallax/view.json
+++ b/Porto-Section-Parallax/view.json
@@ -1,0 +1,17 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "Heading": "#pos_1_1",
+      "SubHeading": "#pos_1_1",
+      "TextLight": "#pos_1_1",
+      "StyleType": "#pos_1_1",
+      "StyleDefault": "#pos_1_1",
+      "StyleParallax": "#pos_1_1",
+      "StyleBackground": "#pos_1_1",
+      "Image": "#pos_1_1",
+      "VideoUrl": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
Adding the OpenContent template for [Porto Sections & Parallax shortcode](https://porto.mandeeps.com/shortcodes/shortcodes-3/sections-parallax)

## Test performed
![SectionsAndParallax](https://user-images.githubusercontent.com/34067433/213372711-8ea7c917-f85e-4746-8dfc-3ec82ae8ff9e.jpg)
