### PR TITLE
Adding the OpenContent Templates for Porto Word Rotator Shortcodes

### DIFF
--- a/Porto-Word-Rotator/Template.hbs
+++ b/Porto-Word-Rotator/Template.hbs
@@ -1,0 +1,33 @@
+{{#each Sections}}
+  <{{Size}} class="mb-sm word-rotator-title">
+    {{Text}}
+    {{#equal Color "transparent"}}
+    <strong>
+      <span
+        class="word-rotate"
+        data-plugin-options="{'delay': 2000, 'animDelay': 300}"
+      >
+        <span class="word-rotate-items">
+          {{#each WordRotate}}
+            <span>{{Value}}</span>
+          {{/each}}
+        </span>
+      </span>
+      </strong>
+    {{else}}
+      <strong class="inverted {{Color}}">
+        <span
+          class="word-rotate"
+          data-plugin-options="{'delay': 2000, 'animDelay': 300}"
+        >
+          <span class="word-rotate-items">
+            {{#each WordRotate}}
+              <span>{{Value}}</span>
+            {{/each}}
+          </span>
+        </span>
+      </strong>
+    {{/equal}}
+    {{OtherText}}
+  </{{Size}}>
+{{/each}}

--- a/Porto-Word-Rotator/builder.json
+++ b/Porto-Word-Rotator/builder.json
@@ -1,0 +1,108 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Sections",
+      "title": "Sections",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "Text",
+          "title": "Text",
+          "fieldtype": "textarea",
+          "advanced": false
+        },
+        {
+          "fieldname": "WordRotate",
+          "title": "Word Rotate",
+          "fieldtype": "array",
+          "subfields": [
+            {
+              "fieldname": "Value",
+              "title": "Value",
+              "fieldtype": "text",
+              "advanced": false
+            }
+          ],
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Color",
+          "title": "Color",
+          "fieldtype": "select",
+          "fieldoptions": [
+            {
+              "value": "transparent",
+              "text": "transparent"
+            },
+            {
+              "value": "inverted-primary",
+              "text": "primary"
+            },
+            {
+              "value": "inverted-secondary",
+              "text": "secondary"
+            },
+            {
+              "value": "inverted-tertiary",
+              "text": "tertiary"
+            },
+            {
+              "value": "inverted-quaternary",
+              "text": "quaternary"
+            }
+          ],
+          "advanced": true,
+          "required": false,
+          "hidden": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Size",
+          "title": "Size",
+          "fieldtype": "select",
+          "fieldoptions": [
+            {
+              "value": "h1",
+              "text": "h1"
+            },
+            {
+              "value": "h2",
+              "text": "h2"
+            },
+            {
+              "value": "h3",
+              "text": "h3"
+            },
+            {
+              "value": "h4",
+              "text": "h4"
+            },
+            {
+              "value": "h5",
+              "text": "h5"
+            },
+            {
+              "value": "h6",
+              "text": "h6"
+            }
+          ],
+          "advanced": false
+        },
+        {
+          "fieldname": "OtherText",
+          "title": "OtherText",
+          "fieldtype": "textarea",
+          "advanced": false
+        }
+      ],
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Word-Rotator/data.json
+++ b/Porto-Word-Rotator/data.json
@@ -1,0 +1,15 @@
+{
+  "Sections": [
+    {
+      "Text": "Some text",
+      "WordRotate": [
+        { "Value": "text1" },
+        { "Value": "text2" },
+        { "Value": "text3" }
+      ],
+      "Color": "inverted-primary",
+      "Size": "h1",
+      "OtherText": "Other Text in here"
+    }
+  ]
+}

--- a/Porto-Word-Rotator/options.json
+++ b/Porto-Word-Rotator/options.json
@@ -1,0 +1,45 @@
+{
+  "fields": {
+    "Sections": {
+      "type": "array",
+      "items": {
+        "fields": {
+          "Text": {
+            "type": "textarea"
+          },
+          "WordRotate": {
+            "type": "array",
+            "items": {
+              "fields": {
+                "Value": {
+                  "type": "text"
+                }
+              }
+            }
+          },
+          "Color": {
+            "type": "select",
+            "sort": false,
+            "optionLabels": [
+              "transparent",
+              "primary",
+              "secondary",
+              "tertiary",
+              "quaternary"
+            ],
+            "removeDefaultNone": true
+          },
+          "Size": {
+            "type": "select",
+            "sort": false,
+            "optionLabels": ["h1", "h2", "h3", "h4", "h5", "h6"],
+            "removeDefaultNone": true
+          },
+          "OtherText": {
+            "type": "textarea"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Word-Rotator/schema.json
+++ b/Porto-Word-Rotator/schema.json
@@ -1,0 +1,54 @@
+{
+  "type": "object",
+  "properties": {
+    "Sections": {
+      "type": "array",
+      "title": "Sections",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "WordRotate": {
+            "type": "array",
+            "title": "Word Rotate",
+            "required": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "Value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              }
+            }
+          },
+          "Color": {
+            "type": "string",
+            "title": "Color",
+            "enum": [
+              "transparent",
+              "inverted-primary",
+              "inverted-secondary",
+              "inverted-tertiary",
+              "inverted-quaternary"
+            ],
+            "removeDefaultNone": true
+          },
+          "Size": {
+            "type": "string",
+            "title": "Size",
+            "enum": ["h1", "h2", "h3", "h4", "h5", "h6"],
+            "removeDefaultNone": true
+          },
+          "OtherText": {
+            "type": "string",
+            "title": "OtherText"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Word-Rotator/view.json
+++ b/Porto-Word-Rotator/view.json
@@ -1,0 +1,9 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "Sections": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
Test Performance
![Template hbs](https://user-images.githubusercontent.com/48692645/213826779-79d367f6-d233-4351-8927-7db1d98fc806.jpg)
