### PR TITLE
Adding the OpenContent Templates for Porto Typography Shortcodes

### DIFF
--- a/Porto-Typography/Template.hbs
+++ b/Porto-Typography/Template.hbs
@@ -1,0 +1,17 @@
+{{#each Sections}}
+{{#equal Class "None"}}
+  <{{Size}} class="mb-sm word-rotator-title">
+     {{Text}}
+     <span class="{{Color}}">{{TextWidthColor}}</span>
+     <span class="alternative-font">{{AlternativeFont}}</span>
+     {{OtherText}}
+  </span>
+ {{else}}
+  <p class="{{Class}}">
+     {{Text}}
+     <span class="{{Color}}">{{TextWidthColor}}</span>
+      <span class="alternative-font">{{AlternativeFont}}</span>
+     {{OtherText}}
+  </p>
+   {{/equal}}
+{{/each}}

--- a/Porto-Typography/builder.json
+++ b/Porto-Typography/builder.json
@@ -1,0 +1,123 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Sections",
+      "title": "Sections",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "Text",
+          "title": "Text",
+          "fieldtype": "textarea",
+          "advanced": false
+        },
+        {
+          "fieldname": "Class",
+          "title": "Class",
+          "fieldtype": "select",
+          "fieldoptions": [
+            {
+              "value": "drop-caps",
+              "text": "Drop Caps"
+            },
+            {
+              "value": "drop-caps drop-caps-style-2",
+              "text": "Drop Caps Style-2"
+            }
+          ],
+          "advanced": true,
+          "required": false,
+          "hidden": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "AlternativeFont",
+          "title": "Alternative Font",
+          "fieldtype": "text",
+          "advanced": false
+        },
+        {
+          "fieldname": "TextWidthColor",
+          "title": "Text Width Color",
+          "fieldtype": "text",
+          "advanced": false
+        },
+        {
+          "fieldname": "Color",
+          "title": "Color",
+          "fieldtype": "select",
+          "fieldoptions": [
+            {
+              "value": "transparent",
+              "text": "transparent"
+            },
+            {
+              "value": "inverted-primary",
+              "text": "primary"
+            },
+            {
+              "value": "inverted-secondary",
+              "text": "secondary"
+            },
+            {
+              "value": "inverted-tertiary",
+              "text": "tertiary"
+            },
+            {
+              "value": "inverted-quaternary",
+              "text": "quaternary"
+            }
+          ],
+          "advanced": true,
+          "required": false,
+          "hidden": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Size",
+          "title": "Size",
+          "fieldtype": "select",
+          "fieldoptions": [
+            {
+              "value": "h1",
+              "text": "h1"
+            },
+            {
+              "value": "h2",
+              "text": "h2"
+            },
+            {
+              "value": "h3",
+              "text": "h3"
+            },
+            {
+              "value": "h4",
+              "text": "h4"
+            },
+            {
+              "value": "h5",
+              "text": "h5"
+            },
+            {
+              "value": "h6",
+              "text": "h6"
+            }
+          ],
+          "advanced": false
+        },
+        {
+          "fieldname": "OtherText",
+          "title": "OtherText",
+          "fieldtype": "textarea",
+          "advanced": false
+        }
+      ],
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Typography/data.json
+++ b/Porto-Typography/data.json
@@ -1,0 +1,13 @@
+{
+  "Sections": [
+    {
+      "Text": "Some text",
+      "Class": "None",
+      "AlternativeFont": "Alternative Font",
+      "TextWidthColor": "Text Width Color",
+      "Color": "text-primary",
+      "Size": "h1",
+      "OtherText": "Other Text in here"
+    }
+  ]
+}

--- a/Porto-Typography/options.json
+++ b/Porto-Typography/options.json
@@ -1,0 +1,45 @@
+{
+  "fields": {
+    "Sections": {
+      "type": "array",
+      "items": {
+        "fields": {
+          "Text": {
+            "type": "textarea"
+          },
+          "Class": {
+            "type": "select",
+            "sort": false,
+            "optionLabels": ["Drop Caps", "Drop Caps Style-2"]
+          },
+          "AlternativeFont": {
+            "type": "text"
+          },
+          "TextWidthColor": {
+            "type": "text"
+          },
+          "Color": {
+            "type": "select",
+            "sort": false,
+            "optionLabels": [
+              "muted",
+              "primary",
+              "success",
+              "info",
+              "warning",
+              "danger"
+            ]
+          },
+          "Size": {
+            "type": "select",
+            "sort": false,
+            "optionLabels": ["h1", "h2", "h3", "h4", "h5", "h6"]
+          },
+          "OtherText": {
+            "type": "textarea"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Typography/schema.json
+++ b/Porto-Typography/schema.json
@@ -1,0 +1,52 @@
+{
+  "type": "object",
+  "properties": {
+    "Sections": {
+      "type": "array",
+      "title": "Sections",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "Class": {
+            "type": "string",
+            "title": "Class",
+            "enum": ["drop-caps", "drop-caps drop-caps-style-2"]
+          },
+          "AlternativeFont": {
+            "type": "string",
+            "title": "Alternative Font"
+          },
+          "TextWidthColor": {
+            "type": "string",
+            "title": "Text Width Color"
+          },
+          "Color": {
+            "type": "string",
+            "title": "Color",
+            "enum": [
+              "text-muted",
+              "text-primary",
+              "text-success",
+              "text-info",
+              "text-warning",
+              "text-danger"
+            ]
+          },
+          "Size": {
+            "type": "string",
+            "title": "Size",
+            "enum": ["h1", "h2", "h3", "h4", "h5", "h6"]
+          },
+          "OtherText": {
+            "type": "string",
+            "title": "OtherText"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Typography/view.json
+++ b/Porto-Typography/view.json
@@ -1,0 +1,9 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "Sections": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
Test Performance

![My WebsiteTypography](https://user-images.githubusercontent.com/48692645/213827396-ec75d72a-599d-4f64-aab6-69a58d8b88c6.jpg)
