### PR TITLE
Fixes in the OpenContent template for Porto Accordion Shortcodes

### DIFF
--- a/Porto-Accordion/Template.hbs
+++ b/Porto-Accordion/Template.hbs
@@ -1,17 +1,16 @@
-<div class="accordion{{Settings.Color}}{{Settings.Size}}{{Settings.Background}}{{Settings.Border}}"
-    id="accordion-{{Context.ModuleId}}">
+<div class="accordion {{#equal Settings.Background "default"}} {{Settings.Color}} {{/equal}} {{Settings.Size}} {{Settings.Background}} {{Settings.Border}}" id="accordion-{{Context.ModuleId}}">
     {{#each Items}}
     <div class="card card-default">
         <div class="card-header">
             <h4 class="card-title">
                 <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion-{{../Context.ModuleId}}"
                     href="#collapse-{{../Context.ModuleId}}-{{@index}}">
-                    {{#if Icon }}<span class="{{Icon}}"></span>{{/if}} {{Title}} </a>
+                    {{#if Icon }}<span class="{{Icon}}"></span>{{/if}} {{Title}}</a>
             </h4>
         </div>
         <div id="collapse-{{../Context.ModuleId}}-{{@index}}" class="accordion-body collapse{{#if @first}} show{{/if}}">
             <div class="card-body">
-                {{{Content}}}
+              {{{Content}}}
             </div>
         </div>
     </div>

--- a/Porto-Accordion/builder.json
+++ b/Porto-Accordion/builder.json
@@ -26,8 +26,14 @@
           "fieldname": "Icon",
           "title": "Icon (optional)",
           "fieldtype": "text",
+          "advanced": true,
+          "required": false,
+          "hidden": false,
           "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>",
-          "advanced": false
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
         }
       ],
       "advanced": false

--- a/Porto-Accordion/schema.json
+++ b/Porto-Accordion/schema.json
@@ -20,8 +20,7 @@
           },
           "Icon": {
             "type": "string",
-            "title": "Icon (optional) - Example: fab fa-android",
-            "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
+            "title": "Icon (optional)"
           }
         }
       }

--- a/Porto-Accordion/template-schema.json
+++ b/Porto-Accordion/template-schema.json
@@ -1,41 +1,31 @@
 {
-    "type": "object",
-    "properties": {
-        "Color": {
-            "title": "Choose the Accordion Color",
-            "type": "string",
-            "enum": [
-                "",
-                " accordion-primary",
-                " accordion-secondary",
-                " accordion-tertiary",
-                " accordion-quaternary"
-            ]
-        },
-        "Size": {
-            "title": "Choose the Accordion Size",
-            "type": "string",
-            "enum": [
-                "",
-                " accordion-sm",
-                " accordion-lg"
-            ]
-        },
-        "Background": {
-            "title": "Include the Background?",
-            "type": "string",
-            "enum": [
-                "",
-                " without-bg"
-            ]
-        },
-        "Border": {
-            "title": "Include the Borders?",
-            "type": "string",
-            "enum": [
-                "",
-                " without-borders"
-            ]
-        }
+  "type": "object",
+  "properties": {
+    "Color": {
+      "title": "Choose the Accordion Color",
+      "type": "string",
+      "enum": [
+        "default",
+        " accordion-primary",
+        " accordion-secondary",
+        " accordion-tertiary",
+        " accordion-quaternary"
+      ]
+    },
+    "Size": {
+      "title": "Choose the Accordion Size",
+      "type": "string",
+      "enum": ["", " accordion-sm", " accordion-lg"]
+    },
+    "Background": {
+      "title": "Include the Background?",
+      "type": "string",
+      "enum": ["default", " without-bg"]
+    },
+    "Border": {
+      "title": "Include the Borders?",
+      "type": "string",
+      "enum": ["", " without-borders"]
     }
+  }
 }


### PR DESCRIPTION
Detected problems:
• In Template Settings, if a non-default color is selected and Background is set to remove, the Tab Title text is not displayed
• In the Form Builder, the icon helper was disabled and does not show href="https://fontawesome.com/icons?d=gallery".

Porto example 
![Accordions](https://user-images.githubusercontent.com/48692645/214748372-27a734dd-1102-4494-b089-acd4dbbfc237.jpg)
Templates for Porto example
![Accordions1](https://user-images.githubusercontent.com/48692645/214748378-7b71b3c2-997c-4215-b15b-75839bc317b7.jpg)
Example of templates for Porto with the problems solved
![Accordions2](https://user-images.githubusercontent.com/48692645/214748389-a9c1e118-e4c5-4117-95ac-22849b5b9c3c.jpg)
