### PR TITLE
Fixes in the OpenContent template for Porto Toggles Shortcodes

### DIFF
--- a/Porto-Toggle/Template.hbs
+++ b/Porto-Toggle/Template.hbs
@@ -4,9 +4,11 @@
     {{#each Items}}
     <section class="toggle{{#equal Active "true"}} active{{/equal}}" id="toggle-{{../Context.ModuleId}}-{{@index}}">
         <button class="toggle-heading" type="button">{{Title}}</button>
-        {{#equal ../Settings.Faq "false"}}<div class="toggle-content">{{/equal}}
-            {{{Content}}}
-            {{#equal ../Settings.Faq "false"}}</div>{{/equal}}
+        {{#equal ../Settings.Faq "false"}}
+            <div class="toggle-content">{{{Content}}}</div>
+        {{else}}
+        <p>{{{Content}}}</p>
+        {{/equal}}
     </section>
     {{/each}}
 </div>

--- a/Porto-Toggle/builder.json
+++ b/Porto-Toggle/builder.json
@@ -19,13 +19,15 @@
         {
           "fieldname": "Content",
           "title": "Content",
-          "fieldtype": "wysihtml",
+          "fieldtype": "textarea",
           "advanced": false
         },
         {
           "fieldname": "Active",
           "title": "Open by Default?",
           "fieldtype": "radio",
+          "vertical": false,
+          "fieldoptions": [],
           "advanced": false
         }
       ],

--- a/Porto-Toggle/options.json
+++ b/Porto-Toggle/options.json
@@ -11,15 +11,13 @@
             "type": "text"
           },
           "Content": {
-            "type": "wysihtml"
+            "type": "textarea"
           },
           "Active": {
             "type": "radio",
-            "optionLabels": [
-              "False",
-              "True"
-            ],
-            "removeDefaultNone": true
+            "sort": false,
+            "optionLabels": [],
+            "vertical": false
           }
         }
       }

--- a/Porto-Toggle/schema.json
+++ b/Porto-Toggle/schema.json
@@ -19,13 +19,9 @@
             "title": "Content"
           },
           "Active": {
-            "type": "array",
+            "type": "string",
             "title": "Open by Default?",
-            "enum": [
-              "false",
-              "true"
-            ],
-            "removeDefaultNone": true
+            "enum": []
           }
         }
       }


### PR DESCRIPTION
Detected problems:
When run as a FAQ the text of the Content overlapped one on top of the other.

Templates for Porto example.
![Toggles Run as an FAQ](https://user-images.githubusercontent.com/48692645/214757850-dcc5b388-000c-4483-8480-d8caaa319af7.jpg)

I change Content fieldtype from wysihtml to textarea. 
Example of templates for Porto with the problems solved.
![Toggles fixed up](https://user-images.githubusercontent.com/48692645/214757980-f3d39a24-d04b-43f9-b3e4-d0baf522f3c6.jpg)



