### PR TITLE
Fixing OpenContent template for Porto Tabs Shortcodes

### DIFF
--- a/Porto-Tabs/Template.hbs
+++ b/Porto-Tabs/Template.hbs
@@ -42,13 +42,22 @@
                         </span>
                     </div>
                 </div>
-                <p class="mb-none pb-none">{{Title}}</p>
                 {{/equal}}
+                <p class="mb-none pb-none">{{Title}}</p>
                 {{/equal}}
                 {{#equal @root.Settings.TabMode "standard"}}
                 {{#if Icon }}<span class="{{Icon}}"></span> {{/if}}{{Title}}
                 {{/equal}}
             </a>
+        </li>
+        {{/each}}
+    </ul>
+    {{/equal}}
+    {{#equal Settings.TabPosition "vertical"}}
+    <ul class="nav nav-tabs col-sm-3">
+        {{#each Items}}
+        <li class="nav-item active">
+            <a class="nav-link" href="#tab-{{../Context.ModuleId}}-{{@index}}" data-toggle="tab">{{Title}}</a>
         </li>
         {{/each}}
     </ul>

--- a/Porto-Tabs/builder.json
+++ b/Porto-Tabs/builder.json
@@ -26,8 +26,14 @@
           "fieldname": "Icon",
           "title": "Icon (optional)",
           "fieldtype": "text",
+          "advanced": true,
+          "required": false,
+          "hidden": false,
           "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>",
-          "advanced": false
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
         }
       ],
       "advanced": false

--- a/Porto-Tabs/options.json
+++ b/Porto-Tabs/options.json
@@ -14,7 +14,8 @@
             "type": "wysihtml"
           },
           "Icon": {
-            "type": "text"
+            "type": "text",
+            "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
           }
         }
       }

--- a/Porto-Tabs/schema.json
+++ b/Porto-Tabs/schema.json
@@ -20,7 +20,8 @@
           },
           "Icon": {
             "type": "string",
-            "title": "Icon (optional)"
+            "title": "Icon (optional) - Example: fab fa-android",
+            "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
           }
         }
       }

--- a/Porto-Tabs/schema.json
+++ b/Porto-Tabs/schema.json
@@ -20,8 +20,7 @@
           },
           "Icon": {
             "type": "string",
-            "title": "Icon (optional) - Example: fab fa-android",
-            "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
+            "title": "Icon (optional)"
           }
         }
       }


### PR DESCRIPTION
Porto Tabs Shortcodes template detected problem:
• If Settings.TabMode is equal to "simple" or Tab Position is in vertical, the title of the tab is not shown.

Porto example.
![Tabs Porto](https://user-images.githubusercontent.com/48692645/214772987-b638e4e6-ab29-4463-8418-624d4025c6ad.jpg)

Templates for Porto example.
![Tabs Position vertical](https://user-images.githubusercontent.com/48692645/214773147-93f9679d-9422-47c1-8e17-9d4fe63fcff2.jpg)

![Tabs Title](https://user-images.githubusercontent.com/48692645/214773205-b6c6032a-b121-4d21-9632-dfa85465ffad.jpg)

Example of templates for Porto with the problems solved.
![Tabs fixed up](https://user-images.githubusercontent.com/48692645/214773480-56a8c520-0b07-4027-abb3-1da85dabc0c3.jpg)
![Tabs Title fixed up](https://user-images.githubusercontent.com/48692645/214773540-7bcd8205-3ae8-4aa4-b767-34719e777a63.jpg)


