### PR TITLE
Fix OpenContent template for Porto Buttons Shortcodes

### DIFF
--- a/Porto-Buttons/builder.json
+++ b/Porto-Buttons/builder.json
@@ -5,6 +5,7 @@
       "title": "Button Text (required)",
       "fieldtype": "wysihtml",
       "advanced": true,
+      "required": false,
       "hidden": false,
       "multilanguage": false,
       "index": false,
@@ -15,8 +16,14 @@
       "fieldname": "Icon",
       "title": "Icon (optional)",
       "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
       "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>",
-      "advanced": false
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
     }
   ],
   "formtype": "object"

--- a/Porto-Buttons/options.json
+++ b/Porto-Buttons/options.json
@@ -4,7 +4,8 @@
       "type": "wysihtml"
     },
     "Icon": {
-      "type": "text"
+      "type": "text",
+      "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
     }
   }
 }

--- a/Porto-Buttons/schema.json
+++ b/Porto-Buttons/schema.json
@@ -7,7 +7,8 @@
     },
     "Icon": {
       "type": "string",
-      "title": "Icon (optional)"
+      "title": "Icon (optional)",
+      "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
     }
   }
 }

--- a/Porto-Buttons/schema.json
+++ b/Porto-Buttons/schema.json
@@ -3,13 +3,11 @@
   "properties": {
     "Button": {
       "type": "string",
-      "title": "Button Text (optional)",
-      "required": false
+      "title": "Button Text (required)"
     },
     "Icon": {
       "type": "string",
-      "title": "Icon (optional) - Example: fas fa-android",
-      "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
+      "title": "Icon (optional)"
     }
   }
 }

--- a/Porto-Buttons/schema.json
+++ b/Porto-Buttons/schema.json
@@ -7,7 +7,7 @@
     },
     "Icon": {
       "type": "string",
-      "title": "Icon (optional)",
+      "title": "Icon (optional) - Example: fas fa-android",
       "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
     }
   }

--- a/Porto-Buttons/view.json
+++ b/Porto-Buttons/view.json
@@ -1,0 +1,10 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "Button": "#pos_1_1",
+      "Icon": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
Porto Buttons Shortcodes template(https://porto.mandeeps.com/shortcodes/shortcodes-2/buttons#):
• It does not have the helper to easily find the documentation of fontawesome.

Fixed up
![Buttons Icon helper](https://user-images.githubusercontent.com/48692645/214872127-55ec37d2-4a36-4d9c-a8eb-b2c436499372.jpg)
