### PR TITLE
Fix OpenContent template for Porto UnOrdered List Shortcodes

### DIFF
--- a/Porto-UnOrdered-List/builder.json
+++ b/Porto-UnOrdered-List/builder.json
@@ -1,5 +1,5 @@
 {
-    "formfields": [
+  "formfields": [
     {
       "fieldname": "ModuleTitle",
       "title": "Module Title",
@@ -26,8 +26,14 @@
           "fieldname": "Icon",
           "title": "Icon (optional)",
           "fieldtype": "text",
+          "advanced": true,
+          "required": false,
+          "hidden": false,
           "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>",
-          "advanced": false
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
         },
         {
           "fieldname": "SecondLevelItems",
@@ -49,17 +55,14 @@
               "fieldname": "SecondLevelListItemIcon",
               "title": "Icon (optional)",
               "fieldtype": "text",
-              "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>",
               "advanced": false
-            }      
+            }
           ],
           "advanced": false
         }
-  
       ],
       "advanced": false
-     }
-    ],
-    "formtype": "object"
-  }
-  
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-UnOrdered-List/options.json
+++ b/Porto-UnOrdered-List/options.json
@@ -1,21 +1,23 @@
 {
-    "fields": {
-      "ModuleTitle": {
-        "type": "text"
-      },
-      "Items": {
-        "type": "array",
-        "items": {
-            "ListItemText": {
-              "type": "wysihtml"
-            },
-            "Icon": {
-              "type": "text"
-            },
-            "SecondLevelItems": 
-            {
-              "type": "array",
-              "items": {
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "Items": {
+      "type": "array",
+      "items": {
+        "fields": {
+          "ListItemText": {
+            "type": "wysihtml"
+          },
+          "Icon": {
+            "type": "text",
+            "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
+          },
+          "SecondLevelItems": {
+            "type": "array",
+            "items": {
+              "fields": {
                 "SecondLevelListItemText": {
                   "type": "wysihtml"
                 },
@@ -23,8 +25,10 @@
                   "type": "text"
                 }
               }
-            }  
-         }
+            }
+          }
+        }
       }
-    }  
+    }
   }
+}

--- a/Porto-UnOrdered-List/schema.json
+++ b/Porto-UnOrdered-List/schema.json
@@ -1,46 +1,43 @@
 {
-    "type": "object",
-    "properties": {
-      "ModuleTitle": {
-        "type": "string",
-        "title": "Module Title"
-      },
-      "Items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "ListItemText": {
-              "type": "string",
-              "title": "List Item Text (required)",
-              "required": true
-            },
-            "Icon": {
-              "type": "string",
-              "title": "Icon (optional) - Example: fab fa-android",
-              "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
-            },
-            "SecondLevelListItems":{
-              "type": "array",
-               "items": {
-                "type": "object",
-                "properties": {
-                  "SecondLevelListItemText": {
-                    "type": "string",
-                    "title": "List Item Text (required)",
-                    "required": true
-                  },
-                  "SecondLevelListItemIcon": {
-                    "type": "string",
-                    "title": "Icon (optional) - Example: fab fa-android",
-                    "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
-                  }
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "Items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ListItemText": {
+            "type": "string",
+            "title": "List Item Text (required)",
+            "required": true
+          },
+          "Icon": {
+            "type": "string",
+            "title": "Icon (optional)"
+          },
+          "SecondLevelItems": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "SecondLevelListItemText": {
+                  "type": "string",
+                  "title": "List Item Text (required)",
+                  "required": true
+                },
+                "SecondLevelListItemIcon": {
+                  "type": "string",
+                  "title": "Icon (optional)"
                 }
-               }
+              }
             }
           }
         }
       }
     }
   }
-  
+}

--- a/Porto-UnOrdered-List/view.json
+++ b/Porto-UnOrdered-List/view.json
@@ -1,0 +1,10 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "Items": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
Porto UnOrdered List Shortcodes templates(https://porto.mandeeps.com/shortcodes/shortcodes-2/lists):
• It does not have the helper to easily find the documentation of fontawesome.
