### PR TITLE
Adding option “Description Lists” in Porto UnOrdered List Shortcodes templates

### DIFF
--- a/Porto-UnOrdered-List/Template.hbs
+++ b/Porto-UnOrdered-List/Template.hbs
@@ -1,3 +1,11 @@
+{{#if Descriptionlists}}
+<dl>
+    {{#each ItemsDescription}}
+    <dt>{{Title}}</dt>
+    <dd>{{ListItemText}}</dd>
+    {{/each}}
+</dl>
+{{else}}
 <ul class="list list-icons {{Settings.IconsColor}} {{Settings.ListBorder}} {{Settings.IconStyle}} {{Settings.IconsSizes}} {{ Settings.IconsPosition}}">
     {{#each Items}}
     <li {{#if @root.Settings.EnableAnimations}}data-appear-animation="{{@root.Settings.AnimationType}}" data-appear-animation-delay="{{@root.Settings.AnimationDelay}}"{{/if}}>
@@ -16,3 +24,4 @@
     </li>    
     {{/each}}
 </ul>   
+{{/if}}

--- a/Porto-UnOrdered-List/builder.json
+++ b/Porto-UnOrdered-List/builder.json
@@ -1,9 +1,15 @@
 {
-    "formfields": [
+  "formfields": [
     {
       "fieldname": "ModuleTitle",
       "title": "Module Title",
       "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "Descriptionlists",
+      "title": "Description lists",
+      "fieldtype": "checkbox",
       "advanced": false
     },
     {
@@ -26,8 +32,14 @@
           "fieldname": "Icon",
           "title": "Icon (optional)",
           "fieldtype": "text",
+          "advanced": true,
+          "required": false,
+          "hidden": false,
           "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>",
-          "advanced": false
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
         },
         {
           "fieldname": "SecondLevelItems",
@@ -49,17 +61,58 @@
               "fieldname": "SecondLevelListItemIcon",
               "title": "Icon (optional)",
               "fieldtype": "text",
-              "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>",
               "advanced": false
-            }      
+            }
           ],
           "advanced": false
         }
-  
       ],
-      "advanced": false
-     }
-    ],
-    "formtype": "object"
-  }
-  
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "Descriptionlists",
+          "values": "false"
+        }
+      ]
+    },
+    {
+      "fieldname": "ItemsDescription",
+      "title": "Items Description",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "Title",
+          "title": "Title",
+          "fieldtype": "text",
+          "advanced": false
+        },
+        {
+          "fieldname": "ListItemText",
+          "title": "List Item Text",
+          "fieldtype": "wysihtml",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        }
+      ],
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "Descriptionlists",
+          "values": "true"
+        }
+      ]
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-UnOrdered-List/options.json
+++ b/Porto-UnOrdered-List/options.json
@@ -1,21 +1,31 @@
 {
-    "fields": {
-      "ModuleTitle": {
-        "type": "text"
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "Descriptionlists": {
+      "type": "checkbox"
+    },
+    "Items": {
+      "type": "array",
+      "dependencies": {
+        "Descriptionlists": [
+          "false"
+        ]
       },
-      "Items": {
-        "type": "array",
-        "items": {
-            "ListItemText": {
-              "type": "wysihtml"
-            },
-            "Icon": {
-              "type": "text"
-            },
-            "SecondLevelItems": 
-            {
-              "type": "array",
-              "items": {
+      "items": {
+        "fields": {
+          "ListItemText": {
+            "type": "wysihtml"
+          },
+          "Icon": {
+            "type": "text",
+            "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
+          },
+          "SecondLevelItems": {
+            "type": "array",
+            "items": {
+              "fields": {
                 "SecondLevelListItemText": {
                   "type": "wysihtml"
                 },
@@ -23,8 +33,28 @@
                   "type": "text"
                 }
               }
-            }  
-         }
+            }
+          }
+        }
       }
-    }  
+    },
+    "ItemsDescription": {
+      "type": "array",
+      "dependencies": {
+        "Descriptionlists": [
+          "true"
+        ]
+      },
+      "items": {
+        "fields": {
+          "Title": {
+            "type": "text"
+          },
+          "ListItemText": {
+            "type": "wysihtml"
+          }
+        }
+      }
+    }
   }
+}

--- a/Porto-UnOrdered-List/schema.json
+++ b/Porto-UnOrdered-List/schema.json
@@ -1,46 +1,71 @@
 {
-    "type": "object",
-    "properties": {
-      "ModuleTitle": {
-        "type": "string",
-        "title": "Module Title"
-      },
-      "Items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "ListItemText": {
-              "type": "string",
-              "title": "List Item Text (required)",
-              "required": true
-            },
-            "Icon": {
-              "type": "string",
-              "title": "Icon (optional) - Example: fab fa-android",
-              "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
-            },
-            "SecondLevelListItems":{
-              "type": "array",
-               "items": {
-                "type": "object",
-                "properties": {
-                  "SecondLevelListItemText": {
-                    "type": "string",
-                    "title": "List Item Text (required)",
-                    "required": true
-                  },
-                  "SecondLevelListItemIcon": {
-                    "type": "string",
-                    "title": "Icon (optional) - Example: fab fa-android",
-                    "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
-                  }
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "Descriptionlists": {
+      "type": "boolean",
+      "title": "Description lists"
+    },
+    "Items": {
+      "type": "array",
+      "dependencies": [
+        "Descriptionlists"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "ListItemText": {
+            "type": "string",
+            "title": "List Item Text (required)",
+            "required": true
+          },
+          "Icon": {
+            "type": "string",
+            "title": "Icon (optional)"
+          },
+          "SecondLevelItems": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "SecondLevelListItemText": {
+                  "type": "string",
+                  "title": "List Item Text (required)",
+                  "required": true
+                },
+                "SecondLevelListItemIcon": {
+                  "type": "string",
+                  "title": "Icon (optional)"
                 }
-               }
+              }
             }
+          }
+        }
+      }
+    },
+    "ItemsDescription": {
+      "type": "array",
+      "title": "Items Description",
+      "dependencies": [
+        "Descriptionlists"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "Title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "ListItemText": {
+            "type": "string",
+            "title": "List Item Text",
+            "required": true
           }
         }
       }
     }
   }
-  
+}

--- a/Porto-UnOrdered-List/view.json
+++ b/Porto-UnOrdered-List/view.json
@@ -1,0 +1,12 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "Descriptionlists": "#pos_1_1",
+      "Items": "#pos_1_1",
+      "ItemsDescription": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
Porto UnOrdered List Shortcodes templates([https://porto.mandeeps.com/shortcodes/shortcodes- 2/lists](https://porto.mandeeps.com/shortcodes/shortcodes-%202/lists)):
•	Missing option “description lists”

Lists Description Porto example
![ Lists Description Porto example](https://user-images.githubusercontent.com/48692645/214894229-495c92f9-8558-4565-8a19-1f15a66408e2.jpg)

Lists Description OpenContent example
![Lists Description OpenContent example](https://user-images.githubusercontent.com/48692645/214894322-32985458-7c6f-4e8a-a252-cbe9023fbe9a.jpg)

