### PR TITLE
Fix OpenContent template for Porto Progress Bar Circular  Shortcodes

### DIFF
--- a/Porto-Progress-Bar-Circular/Template.hbs
+++ b/Porto-Progress-Bar-Circular/Template.hbs
@@ -1,13 +1,13 @@
 <div class="circular-bar">
-			<div class="circular-bar-chart" data-percent="{{CompletedAmmount}}" 
-			data-plugin-options="{'size': '{{Settings.Size}}',
-								 'lineWidth': '{{Settings.lineWidth}}',
-								 'barColor': '#{{Settings.barColor}}',
-								 'trackColor': '#{{Settings.trackColor}}',
-								 {{#if Settings.scaleColor}}'scaleColor': '#{{Settings.scaleColor}}',{{/if}}
-								 'lineCap': '#{{Settings.lineCap}}' 
-								 }"
-			>
-				{{InnerContent}}
-			</div>
+  <div
+    class="circular-bar-chart"
+    data-percent="{{CompletedAmmount}}"
+    data-plugin-options="{ 'size': '{{Settings.Size}}','lineWidth': '{{Settings.lineWidth}}',
+	'barColor': '{{Settings.barColor}}','trackColor': '#{{Settings.trackColor}}',
+	 {{#if Settings.scaleColor}}'scaleColor': '#{{Settings.scaleColor}}',{{/if}}
+	'lineCap': '#{{Settings.lineCap}}'}"
+  >
+    <strong>{{InnerContent}}</strong>
+    <label>{{CompletedAmmount}}%</label>
+  </div>
 </div>

--- a/Porto-Progress-Bar-Circular/template-data.json
+++ b/Porto-Progress-Bar-Circular/template-data.json
@@ -1,8 +1,8 @@
 {
-    "Size": 175, 
-    "lineWidth": 10,
-    "barColor": "0088CC",
-    "lineCap": "square",
-    "scaleColor": "999",
-    "trackColor": "CCC"
+  "Size": 175,
+  "lineWidth": 10,
+  "barColor": "#0088CC",
+  "lineCap": "square",
+  "scaleColor": "#999",
+  "trackColor": "CCC"
 }

--- a/Porto-Progress-Bar-Circular/template-options.json
+++ b/Porto-Progress-Bar-Circular/template-options.json
@@ -1,35 +1,35 @@
 {
-	"fields": {	
-		"Size": {
-			"label": "Progress Bar Size",
-			"type": "text",
-			"removeDefaultNone": true
-		},
-        "lineWidth": {
-			"label": "Progress Bar LineWith",
-			"type": "text",
-			"removeDefaultNone": true
-		},
-        "barColor": {
-			"label": "Progress Bar Bar Color",
-			"type": "text",
-			"removeDefaultNone": true
-		},
-        "lineCap": {
-			"label": "Progress Bar line Cap",
-			"type": "text",
-			"removeDefaultNone": true
-		},
-        "scaleColor": {
-			"label": "Progress Bar Scale Color",
-			"type": "text",
-			"removeDefaultNone": true
-		},
-        "trackColor": {
-			"label": "Progress Bar Track Color",
-			"type": "text",
-			"removeDefaultNone": true
-		}
-
+  "fields": {
+    "Size": {
+      "label": "Progress Bar Size",
+      "type": "text",
+      "removeDefaultNone": true
+    },
+    "lineWidth": {
+      "label": "Progress Bar LineWith",
+      "type": "text",
+      "removeDefaultNone": true
+    },
+    "barColor": {
+      "label": "Progress Bar Color",
+      "type": "text",
+      "removeDefaultNone": true,
+      "helper": "Find values at: <a href=\"https://www.htmlcsscolor.com\" target=\"_blank\">htmlcsscolor</a>"
+    },
+    "lineCap": {
+      "label": "Progress Bar line Cap",
+      "type": "text",
+      "removeDefaultNone": true
+    },
+    "scaleColor": {
+      "label": "Progress Bar Scale Color",
+      "type": "text",
+      "removeDefaultNone": true
+    },
+    "trackColor": {
+      "label": "Progress Bar Track Color",
+      "type": "text",
+      "removeDefaultNone": true
     }
+  }
 }

--- a/Porto-Progress-Bar-Circular/template-schema.json
+++ b/Porto-Progress-Bar-Circular/template-schema.json
@@ -1,37 +1,38 @@
 {
-    "type": "object",
-    "properties": {
-      "Size": {
-        "type": "number",
-        "title": "Progress Bar Size",
-        "default": 175,
-        "minimum": 60
-      },
-      "lineWidth": {
-        "type": "number",
-        "title": "Progress Bar LineWith",
-        "default": 10,
-        "minimum": 4
-      },
-      "barColor": {
-        "type": "string",
-        "title": "Progress Bar Bar Color",
-        "default": "0088CC"
-      },
-      "lineCap": {
-        "type": "string",
-        "title": "Progress Bar line Cap",
-        "default": "square"
-      },
-      "scaleColor": {
-        "type": "string",
-        "title": "Progress Bar Scale Color",
-        "default": "999" 
-      },
-      "trackColor": {
-        "type": "string",
-        "title": "Progress Bar Track Color",
-        "default": "CCC"
-      }
+  "type": "object",
+  "properties": {
+    "Size": {
+      "type": "number",
+      "title": "Progress Bar Size",
+      "default": 175,
+      "minimum": 60
+    },
+    "lineWidth": {
+      "type": "number",
+      "title": "Progress Bar LineWith",
+      "default": 10,
+      "minimum": 4
+    },
+    "barColor": {
+      "type": "string",
+      "title": "Progress Bar Color",
+      "helper": "Find values at: <a href=\"https://www.htmlcsscolor.com\" target=\"_blank\">htmlcsscolor</a>",
+      "default": "#0088CC"
+    },
+    "lineCap": {
+      "type": "string",
+      "title": "Progress Bar line Cap",
+      "default": "square"
+    },
+    "scaleColor": {
+      "type": "string",
+      "title": "Progress Bar Scale Color",
+      "default": "#999"
+    },
+    "trackColor": {
+      "type": "string",
+      "title": "Progress Bar Track Color",
+      "default": "CCC"
     }
+  }
 }


### PR DESCRIPTION
Porto Progress Bar Circular Shortcodes templates(https://porto.mandeeps.com/shortcodes/shortcodes-3/progress-bar)
•	When "Completed Amount" is modified, the circular bar layout is unmounted.
•	It does not have the helper to easily find the documentation of HTML CSS Color Picker,

Porto Progress Bar Circular example
![Porto Progress Bar Circular example](https://user-images.githubusercontent.com/48692645/215000671-5942c344-c7fe-4a23-a156-e96bce9b98cf.jpg)

Progress Bars Circular OpenContent example
![Progress Bars Circular OpenContent example](https://user-images.githubusercontent.com/48692645/215000686-f9424cb6-6842-4aff-975f-b84a5ab8c195.jpg)

Progress Bars openContent fixed up
![Progress Bars openContent fixed up](https://user-images.githubusercontent.com/48692645/215000696-0e6db09d-e9f8-43e4-8adc-b3585b56aa8a.jpg)
