### PR TITLE
Fix OpenContent template for Porto Divider Shortcodes

### DIFF
--- a/Porto-Dividers/Template.hbs
+++ b/Porto-Dividers/Template.hbs
@@ -14,10 +14,10 @@
 </div>
 {{else}}
     {{#equal Settings.DividerType "Classic"}}
-        <hr class="{{Settings.PatternStyle}} {{Settings.Spacements}}" />
+        <hr class="{{Settings.Spacements}}" />
     {{else}}
         <div class="divider divider-small {{Settings.Color}} {{Settings.DividerSmallLocation}} {{Settings.DividerSmallSize}} {{Settings.Spacements}}">
-                    <hr />
+            <hr />
         </div>
     {{/equal}}
 {{/equal}}

--- a/Porto-Dividers/template-data.json
+++ b/Porto-Dividers/template-data.json
@@ -1,12 +1,12 @@
 {
-    "DividerType": "Classic",
-    "IconsSizes": "",
-    "IconsPosition": "",
-    "DividerSmallLocation": "",
-    "FullWith": false,
-    "Spacements": "short",
-    "Styles": "solid",
-    "Color": "",
-    "DividerStyle": "",
-    "EnableAnimations": false
+  "DividerType": "Classic",
+  "IconsSizes": "",
+  "IconsPosition": "",
+  "DividerSmallLocation": "",
+  "FullWith": false,
+  "Spacements": "tall",
+  "Styles": "solid",
+  "Color": "",
+  "DividerStyle": "",
+  "EnableAnimations": false
 }


### PR DESCRIPTION
Porto Dividers Shortcodes template(https://porto.mandeeps.com/shortcodes/shortcodes-4/dividers):
 • When the Settings.DividerType is equal to "Classic" the divider is barely visible.
