### PR TITLE
Fix OpenContent template for Porto Countdowns Shortcodes 

### DIFF
--- a/Porto-Countdowns/Template.hbs
+++ b/Porto-Countdowns/Template.hbs
@@ -1,1 +1,24 @@
-<div class="{{Settings.CountdownsStyle}}" data-plugin-countdown data-plugin-options="{'date': '{{DateTime}}', 'numberClass': 'font-weight-extra-bold'}"></div>
+{{#equal Settings.CountdownsStyle "parallax"}}
+  <section
+    class="parallax section section-text-light section-parallax section-center mt-none"
+    data-plugin-options="{'speed': 1.5}"
+    data-plugin-parallax="parallax"
+    data-image-src="{{ParallaxImage}}"
+  >
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12"><div
+            class="countdown countdown-light"
+            data-plugin-countdown
+            data-plugin-options="{'date': '{{DateTime}}', 'numberClass': 'font-weight-extra-bold'}"
+          ></div></div>
+      </div>
+    </div>
+  </section>
+{{else}}
+  <div
+    class="{{Settings.CountdownsStyle}}"
+    data-plugin-countdown
+    data-plugin-options="{'date': '{{DateTime}}', 'numberClass': 'font-weight-extra-bold'}"
+  ></div>
+{{/equal}}

--- a/Porto-Countdowns/builder.json
+++ b/Porto-Countdowns/builder.json
@@ -12,6 +12,13 @@
       "index": false,
       "position": "1col1",
       "dependencies": []
+    },
+    {
+      "fieldname": "ParallaxImage",
+      "title": "Parallax Image (required if Countdowns Style is equal to \"Inside Parallax\" )",
+      "fieldtype": "image",
+      "imageoptions": {},
+      "advanced": false
     }
   ],
   "formtype": "object"

--- a/Porto-Countdowns/options.json
+++ b/Porto-Countdowns/options.json
@@ -3,6 +3,9 @@
     "DateTime": {
       "type": "text",
       "placeholder": "Use Format Year/Month/Day Hour:Minutes/Seconds"
+    },
+    "ParallaxImage": {
+      "type": "image"
     }
   }
 }

--- a/Porto-Countdowns/schema.json
+++ b/Porto-Countdowns/schema.json
@@ -6,6 +6,10 @@
       "title": "DateTime (required)",
       "placeholder": "Use Format YYYY/MM/DD h:mm:ss",
       "required": true
+    },
+    "ParallaxImage": {
+      "type": "string",
+      "title": "Parallax Image (required if Countdowns Style is equal to \"Inside Parallax\" )"
     }
   }
 }

--- a/Porto-Countdowns/template-schema.json
+++ b/Porto-Countdowns/template-schema.json
@@ -1,16 +1,16 @@
 {
-    "type": "object",
-    "properties": {        
-        "CountdownsStyle": {
-            "title": "Countdowns Style",
-            "type": "string",
-            "enum": [
-				"countdown",
-                "countdown countdown-primary",
-                "countdown countdown-borders",
-                "countdown countdown-borders countdown-primary",
-                "countdown countdown-light"
-            ]
-        }
-    }    
+  "type": "object",
+  "properties": {
+    "CountdownsStyle": {
+      "title": "Countdowns Style",
+      "type": "string",
+      "enum": [
+        "countdown",
+        "countdown countdown-primary",
+        "countdown countdown-borders",
+        "countdown countdown-borders countdown-primary",
+        "parallax"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Porto Dividers Shortcodes template(https://porto.mandeeps.com/shortcodes/shortcodes-3/countdowns):
    •	When the Countdowns Style is equal to "Inside Parallax" does not show any data

OpenContent example with error
![Porto Templates Countdowns](https://user-images.githubusercontent.com/48692645/215140632-f4dd9df4-40c2-4744-958f-fe59940421c3.jpg)

Porto Example
![Porto Shortcodes Countdowns](https://user-images.githubusercontent.com/48692645/215140610-21b9c519-22e3-4ccd-b543-add07ca5e7fe.jpg)

Fixed up
![Porto Templates  Countdowns](https://user-images.githubusercontent.com/48692645/215140618-da16971d-8e93-4b08-85dd-93840c954a32.jpg)


