### PR TITLE
Added Parallax option in Pricing Tables

### DIFF
--- a/Porto-Pricing-Tables/Template.hbs
+++ b/Porto-Pricing-Tables/Template.hbs
@@ -1,3 +1,7 @@
+{{#equal Settings.PricingTableStyle 'Parallax'}}
+<section class="parallax section section-text-light section-parallax mt-none mb-none" data-image-src="{{ParallaxImage}}" data-plugin-options="{'speed': 1.5}" data-plugin-parallax="parallax">
+    <div class="container">
+{{/equal}}
 <div class="pricing-table{{#if Settings.PricingTableStyle}} {{Settings.PricingTableStyle}}{{/if}}
 {{#if Settings.PricingTableSize}} {{Settings.PricingTableSize}}{{/if}}">
     <div class="row">  
@@ -38,3 +42,7 @@
         {{/each}}     
     </div>
 </div>
+{{#equal Settings.PricingTableStyle 'Parallax'}}
+  </div>
+</section>
+{{/equal}}

--- a/Porto-Pricing-Tables/builder.json
+++ b/Porto-Pricing-Tables/builder.json
@@ -1,89 +1,96 @@
 {
-    "formfields": [
-      {
-        "fieldname": "ModuleTitle",
-        "title": "Module Title",
-        "fieldtype": "text",
-        "advanced": false
-      },
-      {
-        "fieldname": "Items",
-        "fieldtype": "array",
-        "subfields": [
-          {
-            "fieldname": "Title",
-            "title": "Title (required)",
-            "fieldtype": "text",
-            "advanced": true,
-            "required":true,
-            "hidden": false,
-            "multilanguage": false,
-            "index": false,
-            "position": "1col1",
-            "dependencies": []
-          },
-          {
-            "fieldname": "Description",
-            "title": "Description (optional)",
-            "fieldtype": "wysihtml",
-            "advanced": false
-          },
-          {
-            "fieldname": "Price",
-            "title": "Price (required)",
-            "fieldtype": "text",
-            "advanced": true,
-            "required":true,
-            "hidden": false,
-            "multilanguage": false,
-            "index": false,
-            "position": "1col1",
-            "dependencies": []
-          },          
-          {
-            "fieldname": "ActionButtonText",
-            "title": "Action Button Text (required)",
-            "fieldtype": "text",
-            "advanced": true,
-            "required":true,
-            "hidden": false,
-            "multilanguage": false,
-            "index": false,
-            "position": "1col1",
-            "dependencies": []
-          },
-          {
-            "fieldname": "MostPopular",
-            "fieldtype": "checkbox",
-            "advanced": false
-          },          
-          {
-            "fieldname": "ShowPopularRibbon",
-            "fieldtype": "checkbox",
-            "advanced": false
-          },
-          {
-            "fieldname": "Features",
-            "fieldtype": "array",
-            "subfields": [
-              {
-                "fieldname": "FeatureDescriptionText",
-                "title": "Feature Description (required)",
-                "fieldtype": "wysihtml",
-                "advanced": true,
-                "required": true,
-                "hidden": false,
-                "multilanguage": false,
-                "index": false,
-                "position": "1col1",
-                "dependencies": []
-              }     
-            ],
-            "advanced": false
-          }
-        ],
-        "advanced": false
-      }
-    ],
-    "formtype": "object"
-  }
+  "formfields": [
+    {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ParallaxImage",
+      "title": "Parallax Image",
+      "fieldtype": "image",
+      "imageoptions": {},
+      "advanced": false
+    },
+    {
+      "fieldname": "Items",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "Title",
+          "title": "Title (required)",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Description",
+          "title": "Description (optional)",
+          "fieldtype": "wysihtml",
+          "advanced": false
+        },
+        {
+          "fieldname": "Price",
+          "title": "Price (required)",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "ActionButtonText",
+          "title": "Action Button Text (required)",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "MostPopular",
+          "fieldtype": "checkbox",
+          "advanced": false
+        },
+        {
+          "fieldname": "ShowPopularRibbon",
+          "fieldtype": "checkbox",
+          "advanced": false
+        },
+        {
+          "fieldname": "Features",
+          "fieldtype": "array",
+          "subfields": [
+            {
+              "fieldname": "FeatureDescriptionText",
+              "title": "Feature Description (required)",
+              "fieldtype": "wysihtml",
+              "advanced": true,
+              "required": true,
+              "hidden": false,
+              "multilanguage": false,
+              "index": false,
+              "position": "1col1",
+              "dependencies": []
+            }
+          ],
+          "advanced": false
+        }
+      ],
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Pricing-Tables/options.json
+++ b/Porto-Pricing-Tables/options.json
@@ -1,48 +1,45 @@
 {
-    "fields": {
-      "ModuleTitle": {
-        "type": "text"
-      },
-      "Items": {
-        "type": "array",
-        "items": {
-            "Title": {
-              "type": "text"
-            },
-            "Description": {
-              "type": "text"
-            },
-            "Price": {
-                "type": "text"
-            },
-            "ActionButtonText":{
-                "type": "text"
-            },
-            "MostPopular": {
-              "type": "checkbox",
-              "label": "Most Popular:",
-              "rightLabel": "Set as most popular?",
-              "removeDefaultNone": true
-            },
-            "ShowPopularRibbon": {
-              "type": "checkbox",
-              "label": "Popular Ribbon:",
-              "rightLabel": "Show Popular Ribbon?",
-              "removeDefaultNone": true,
-              "dependencies": {
-                  "MostPopular": true
-              }
-            },            
-            "Features": 
-            {
-              "type": "array",
-              "items": {
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ParallaxImage": {
+      "type": "image"
+    },
+    "Items": {
+      "type": "array",
+      "items": {
+        "fields": {
+          "Title": {
+            "type": "text"
+          },
+          "Description": {
+            "type": "wysihtml"
+          },
+          "Price": {
+            "type": "text"
+          },
+          "ActionButtonText": {
+            "type": "text"
+          },
+          "MostPopular": {
+            "type": "checkbox"
+          },
+          "ShowPopularRibbon": {
+            "type": "checkbox"
+          },
+          "Features": {
+            "type": "array",
+            "items": {
+              "fields": {
                 "FeatureDescriptionText": {
                   "type": "wysihtml"
                 }
               }
-            }  
-         }
+            }
+          }
+        }
       }
-    }  
+    }
   }
+}

--- a/Porto-Pricing-Tables/schema.json
+++ b/Porto-Pricing-Tables/schema.json
@@ -1,64 +1,59 @@
 {
-    "type": "object",
-    "properties": {
-      "ModuleTitle": {
-        "type": "string",
-        "title": "Module Title"
-      },
-      "Items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "Title": {
-              "type": "string",
-              "title": "Title (required)",
-              "required": true
-            },
-            "Description": {
-              "type": "string",
-              "title": "Description (optional)"
-            },
-            "Price": {
-                "type": "number",
-                "title": "Price (required)",
-                "required": true,
-                "minimum": 0
-            }, 
-            "ActionButtonText": {
-              "type": "string",
-              "title": "Action Button Text (required)",
-              "required": true
-            },
-            "MostPopular": {    
-                "title": "Most Popular",
-                "type": "boolean",
-                "default": false        
-            },
-            "ShowPopularRibbon": {
-                "title": "Show Popular Ribbon",    
-                "type": "boolean",
-                "default": false        
-            },
-            "Features":{
-              "type": "array",
-               "items": {
-                "type": "object",
-                "properties": {
-                  "FeatureDescriptionText": {
-                    "type": "string",
-                    "title": "Feature Description (required)",
-                    "required": true
-                  }
-                }
-               }
-            }
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ParallaxImage": {
+      "type": "string",
+      "title": "Parallax Image"
+    },
+    "Items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Title": {
+            "type": "string",
+            "title": "Title (required)",
+            "required": true
           },
-          "dependencies": {        
-              "ShowPopularRibbon": ["MostPopular"]
+          "Description": {
+            "type": "string",
+            "title": "Description (optional)"
+          },
+          "Price": {
+            "type": "string",
+            "title": "Price (required)",
+            "required": true
+          },
+          "ActionButtonText": {
+            "type": "string",
+            "title": "Action Button Text (required)",
+            "required": true
+          },
+          "MostPopular": {
+            "type": "boolean"
+          },
+          "ShowPopularRibbon": {
+            "type": "boolean"
+          },
+          "Features": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "FeatureDescriptionText": {
+                  "type": "string",
+                  "title": "Feature Description (required)",
+                  "required": true
+                }
+              }
+            }
           }
         }
       }
     }
   }
-  
+}

--- a/Porto-Pricing-Tables/template-options.json
+++ b/Porto-Pricing-Tables/template-options.json
@@ -1,22 +1,16 @@
 {
-	"fields": {		
-		"PricingTableStyle": {
-			"title": "Pricing Table Style",
-			"type": "select",
-			"optionLabels": [
-				"Style 1",				
-				"Style 2"
-			],
-			"removeDefaultNone": true
-        },
-        "PricingTableSize": {
-			"title": "Pricing Table Size",
-			"type": "select",
-			"optionLabels": [
-				"Standard",				
-				"Small"
-			],
-			"removeDefaultNone": true
-        }
+  "fields": {
+    "PricingTableStyle": {
+      "title": "Pricing Table Style",
+      "type": "select",
+      "optionLabels": ["Style 1", "Style 2", "Parallax"],
+      "removeDefaultNone": true
+    },
+    "PricingTableSize": {
+      "title": "Pricing Table Size",
+      "type": "select",
+      "optionLabels": ["Standard", "Small"],
+      "removeDefaultNone": true
     }
+  }
 }

--- a/Porto-Pricing-Tables/template-schema.json
+++ b/Porto-Pricing-Tables/template-schema.json
@@ -1,23 +1,17 @@
 {
-    "type": "object",
-    "properties": {  
-        "PricingTableStyle": {
-            "title": "Pricing Table Style",
-            "type": "string",
-            "enum": [
-                "",
-                "princig-table-flat"
-            ],
-            "default": ""
-        },
-        "PricingTableSize": {
-            "title": "Pricing Table Size",
-            "type": "string",
-            "enum": [
-                "",
-                "pricing-table-sm"
-            ],
-            "default": ""
-        }
+  "type": "object",
+  "properties": {
+    "PricingTableStyle": {
+      "title": "Pricing Table Style",
+      "type": "string",
+      "enum": ["", "princig-table-flat", "Parallax"],
+      "default": ""
+    },
+    "PricingTableSize": {
+      "title": "Pricing Table Size",
+      "type": "string",
+      "enum": ["", "pricing-table-sm"],
+      "default": ""
     }
+  }
 }


### PR DESCRIPTION
Porto Pricing Tables Shortcodes template(https://porto.mandeeps.com/shortcodes/shortcodes-3/pricing-tables).
•	There is no option to use parallax

![Pricing Tables with parallax](https://user-images.githubusercontent.com/48692645/215205030-647bfdfb-c2cb-46eb-9d5e-0479d2e75564.jpg)
