### PR TITLE
Fix OpenContent template for Porto Carroucel Shortcodes

### DIFF
--- a/Porto-Carousel/Template-data.json
+++ b/Porto-Carousel/Template-data.json
@@ -6,5 +6,5 @@
   "Loop": "true",
   "Autoplay": "true",
   "AutoplayTimeout": "3000",
-  "FullWidth": "false"
+  "Style": "Default"
 }

--- a/Porto-Carousel/Template.hbs
+++ b/Porto-Carousel/Template.hbs
@@ -1,4 +1,4 @@
-{{#if Settings.FullWidth}}
+{{#equal Settings.Style "FullWidth"}}
 <div class="owl-carousel full-width" data-plugin-options="{'items': 5, 'loop': false, 'nav': true, 'dots': false}">
 	{{#each Items}}
 	<div>
@@ -18,8 +18,8 @@
 	</div>
 	 {{/each}}
 </div>
-{{else}}
-{{#if Settings.InsideText}}
+{{/equal}}
+{{#equal Settings.Style "InsideText"}}
 <div class="row">
 	<div class="col-md-12">
 		<p>{{InnerTopText}}</p>
@@ -36,8 +36,8 @@
 		{{/each}}
 	</div>
 </div>
-{{else}}
-{{#if Settings.HoverStyle}}
+{{/equal}}
+{{#equal Settings.Style "HoverStyle"}}
 <div class="event pt-md">
   <div class="row">
     <div class="col-md-12">
@@ -74,7 +74,8 @@
     </div>
   </div>
 </div>
-{{else}}
+{{/equal}}
+{{#equal Settings.Style "Default"}}
 <div
   class="owl-carousel {{Settings.Navigation}} {{#if Settings.RoundedNav}} rounded-nav {{/if}}"
   data-plugin-options="{'items': {{Settings.NumberOfItems}}, 'margin': 10, 'loop': {{#if Settings.Loop}} true {{else}} false {{/if}}, 
@@ -96,7 +97,13 @@
 	</div>
   {{/each}}
 </div>
-
-{{/if}}
-{{/if}}
-{{/if}}
+{{/equal}}
+{{#equal Settings.Style "Videos"}}
+<div class="owl-carousel manual" id="videos">
+	{{#each Videos}}
+	<div class="item-video" data-merge="3">
+        <a class="owl-video" href="{{Url}}"> <span class="btn-text-indent">{{TextIndent}}</span> </a>
+    </div>
+	{{/each}}
+</div>
+{{/equal}}

--- a/Porto-Carousel/builder.json
+++ b/Porto-Carousel/builder.json
@@ -71,7 +71,14 @@
               "fieldname": "Icon",
               "title": "Icon",
               "fieldtype": "text",
-              "advanced": false
+              "advanced": true,
+              "required": false,
+              "hidden": false,
+              "helper": "Find values at: <a href=\\\"https://fontawesome.com/icons?d=gallery\\\" target=\\\"_blank\\\">FontAwesome</a>",
+              "multilanguage": false,
+              "index": false,
+              "position": "1col1",
+              "dependencies": []
             }
           ],
           "advanced": false
@@ -85,6 +92,26 @@
         {
           "fieldname": "FullWidthProjectType",
           "title": "Full Width Project Type ( Only is FullWidth True )",
+          "fieldtype": "text",
+          "advanced": false
+        }
+      ],
+      "advanced": false
+    },
+    {
+      "fieldname": "Videos",
+      "title": "Videos",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "Url",
+          "title": "Url",
+          "fieldtype": "text",
+          "advanced": false
+        },
+        {
+          "fieldname": "TextIndent",
+          "title": "Text Indent",
           "fieldtype": "text",
           "advanced": false
         }

--- a/Porto-Carousel/options.json
+++ b/Porto-Carousel/options.json
@@ -40,7 +40,8 @@
                   "type": "text"
                 },
                 "Icon": {
-                  "type": "text"
+                  "type": "text",
+                  "helper": "Find values at: <a href=\\\"https://fontawesome.com/icons?d=gallery\\\" target=\\\"_blank\\\">FontAwesome</a>"
                 }
               }
             }
@@ -49,6 +50,19 @@
             "type": "text"
           },
           "FullWidthProjectType": {
+            "type": "text"
+          }
+        }
+      }
+    },
+    "Videos": {
+      "type": "array",
+      "items": {
+        "fields": {
+          "Url": {
+            "type": "text"
+          },
+          "TextIndent": {
             "type": "text"
           }
         }

--- a/Porto-Carousel/schema.json
+++ b/Porto-Carousel/schema.json
@@ -71,6 +71,23 @@
           }
         }
       }
+    },
+    "Videos": {
+      "type": "array",
+      "title": "Videos",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "TextIndent": {
+            "type": "string",
+            "title": "Text Indent"
+          }
+        }
+      }
     }
   }
 }

--- a/Porto-Carousel/template-options.json
+++ b/Porto-Carousel/template-options.json
@@ -17,19 +17,16 @@
       ],
       "removeDefaultNone": true
     },
-    "FullWidth": {
-      "label": "Full Width",
-      "type": "checkbox",
-      "removeDefaultNone": true
-    },
-    "InsideText": {
-      "label": "Inside Text",
-      "type": "checkbox",
-      "removeDefaultNone": true
-    },
-    "HoverStyle": {
-      "label": "Hover Style",
-      "type": "checkbox",
+    "Style": {
+      "title": "Style",
+      "type": "select",
+      "optionLabels": [
+        "Default",
+        "FullWidth",
+        "InsideText",
+        "HoverStyle",
+        "Videos"
+      ],
       "removeDefaultNone": true
     },
     "ShowData": {

--- a/Porto-Carousel/template-schema.json
+++ b/Porto-Carousel/template-schema.json
@@ -11,17 +11,10 @@
       "type": "select",
       "enum": ["stage-margin", "show-nav-hover", "show-nav-title", "nav-bottom"]
     },
-    "FullWidth": {
-      "title": "FullWidth",
-      "type": "boolean"
-    },
-    "InsideText": {
-      "title": "InsideText",
-      "type": "boolean"
-    },
-    "HoverStyle": {
-      "title": "HoverStyle",
-      "type": "boolean"
+    "Style": {
+      "title": "Style",
+      "type": "select",
+      "enum": ["Default", "FullWidth", "InsideText", "HoverStyle", "Videos"]
     },
     "ShowData": {
       "title": "ShowData",

--- a/Porto-Carousel/view.json
+++ b/Porto-Carousel/view.json
@@ -5,7 +5,8 @@
     "bindings": {
       "InnerTopText": "#pos_1_1",
       "ItemsInnerText": "#pos_1_1",
-      "Items": "#pos_1_1"
+      "Items": "#pos_1_1",
+      "Videos": "#pos_1_1"
     }
   }
 }


### PR DESCRIPTION
Porto Carroucel Shortcodes template(https://porto.mandeeps.com/shortcodes/shortcodes-1/carousel):

- Missing option or style to display videos
- Missing to add a helper for the icons

Test Performance
![Test Porto Templates Carousel](https://user-images.githubusercontent.com/48692645/215606773-1d5b0fe4-ad64-4f7a-a96b-8775215cf2a1.jpg)
