### PR TITLE
Fix OpenContent template for Porto Modal Forms Shortcodes

### DIFF
--- a/Porto-Modals-Forms/builder.json
+++ b/Porto-Modals-Forms/builder.json
@@ -1,6 +1,12 @@
 {
   "formfields": [
     {
+      "fieldname": "ButtonTitle",
+      "title": "ButtonTitle",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
       "fieldname": "ModalTitle",
       "title": "Modal Title (required)",
       "fieldtype": "text",

--- a/Porto-Modals-Forms/options.json
+++ b/Porto-Modals-Forms/options.json
@@ -1,5 +1,8 @@
 {
   "fields": {
+    "ButtonTitle": {
+      "type": "text"
+    },
     "ModalTitle": {
       "type": "text"
     },

--- a/Porto-Modals-Forms/schema.json
+++ b/Porto-Modals-Forms/schema.json
@@ -1,6 +1,10 @@
 {
   "type": "object",
   "properties": {
+    "ButtonTitle": {
+      "type": "string",
+      "title": "ButtonTitle"
+    },
     "ModalTitle": {
       "type": "string",
       "title": "Modal Title (required)",

--- a/Porto-Modals-Forms/view.json
+++ b/Porto-Modals-Forms/view.json
@@ -3,6 +3,7 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ButtonTitle": "#pos_1_1",
       "ModalTitle": "#pos_1_1",
       "Items": "#pos_1_1"
     }


### PR DESCRIPTION
Porto Modal Forms Shortcodes template (https://porto.mandeeps.com/shortcodes/shortcodes-1/modals)

- When the template is added for the first time, the button has a text by default, but since there is no option in the edit to change that text, when the form is modified, said button text is lost.

Porto Modal Templates example
![Porto Modal Templates example 1](https://user-images.githubusercontent.com/48692645/215613209-c691bf5f-5a1d-4cbc-a31e-73b69e0b9c1e.jpg)

 Porto Modal Forms Templates fixed up
![ Porto Modal Forms Templates fixed up](https://user-images.githubusercontent.com/48692645/215613202-ccb0c5fb-4713-4c32-9ec5-5bae16ab4802.jpg)