### PR TITLE
Fix OpenContent template for Porto Image Frames Shortcodes

### DIFF
--- a/Porto-Image-Frames/Template.hbs
+++ b/Porto-Image-Frames/Template.hbs
@@ -22,7 +22,7 @@
     {{#equal HoverStyles "thumb-info-lighten"}}
       <div class="{{GridWidth}}">
         <a href="#">
-          <div class="thumb-info {{#if NoBorders}} thumb-info-no-borders {{/if}}">
+          <div class="thumb-info thumb-info-lighten {{#if NoBorders}} thumb-info-no-borders {{/if}}">
             <span class="thumb-info-wrapper">
               <img
                 alt="Project-Image"
@@ -74,18 +74,10 @@
               src="{{Image}}"
               class="img-fluid {{DefaultStyles}}"
             />
-            {{#equal Bottom "thumb-info-bottom-info-dark"}}
               <span class="thumb-info-title">
                 <span class="thumb-info-inner">{{ProjectTitle}}</span>
                 <span class="thumb-info-type">{{ProjectType}}</span>
               </span>
-            {{/equal}}
-            {{#equal Bottom "thumb-info-bottom-info"}}
-              <span class="thumb-info-title">
-                <span class="thumb-info-inner">{{ProjectTitle}}</span>
-                <span class="thumb-info-type">{{ProjectType}}</span>
-              </span>
-            {{/equal}}
             <span class="thumb-info-action">
               {{#each Icons}}
               <a href="{{href}}">
@@ -102,7 +94,7 @@
     {{/equal}}
     {{#equal HoverStyles "Icons Colors"}}
       <div class="{{GridWidth}}">
-        <div class="thumb-info thumb-info-centered-icons {{#if NoBorders}} thumb-info-no-borders {{/if}}">
+        <div class="thumb-info thumb-info-centered-icons {{Bottom}} {{#if NoBorders}} thumb-info-no-borders {{/if}}">
           <span class="thumb-info-wrapper">
             <img
               alt="Project-Image"
@@ -123,6 +115,37 @@
         </div>
       </div>
     {{/equal}}
+    {{#equal HoverStyles "Hide Info Hover"}}
+    <div class="{{GridWidth}}">
+      <a href="#">
+        <div class="thumb-info thumb-info-centered-info thumb-info-hide-info-hover">
+          <span class="thumb-info-wrapper">
+            <img alt="Project-Image" src="{{Image}}" class="img-fluid" />
+            <span class="thumb-info-title">
+             <span class="thumb-info-inner">{{ProjectTitle}}</span>
+						<span class="thumb-info-type">{{ProjectType}}</span>
+            </span>
+          </span>
+        </div> <span class="btn-text-indent">Single Project</span>
+      </a>
+    </div>
+    {{/equal}}
+     {{#equal HoverStyles "thumb-info-centered-info"}}
+      <div class="{{GridWidth}}">
+     <a href="#">
+			<div class="thumb-info thumb-info-centered-info">
+				<span class="thumb-info-wrapper">
+					<img alt="Project-Image" src="{{Image}}" class="img-fluid" />
+					<span class="thumb-info-title">
+						<span class="thumb-info-inner">{{ProjectTitle}}</span>
+						<span class="thumb-info-type">{{ProjectType}}</span>
+					</span>
+					<span class="thumb-info-action-icon"> <em class="fas fa-link"></em> </span>
+				</span>
+			</div> <span class="btn-text-indent">Single Project</span>
+		</a>
+    </div>
+     {{/equal}}
     {{#equal HoverStyles "FadeIn"}}
     <div class="{{GridWidth}}">
 		<div class="appear-animation restaurant" data-appear-animation="fadeIn" data-appear-animation-delay="0">

--- a/Porto-Image-Frames/builder.json
+++ b/Porto-Image-Frames/builder.json
@@ -39,6 +39,10 @@
               "text": "Centered Info"
             },
             {
+              "value": "Hide Info Hover",
+              "text": "Hide Info Hover"
+            },
+            {
               "value": "FadeIn",
               "text": "FadeIn"
             },
@@ -54,10 +58,6 @@
           "title": "Default Styles",
           "fieldtype": "select",
           "fieldoptions": [
-            {
-              "value": "rounded",
-              "text": "rounded"
-            },
             {
               "value": "rounded-circle",
               "text": "rounded-circle"
@@ -243,7 +243,14 @@
               "fieldname": "Name",
               "title": "Name",
               "fieldtype": "text",
-              "advanced": false
+              "advanced": true,
+              "required": false,
+              "hidden": false,
+              "placeholder": "facebook",
+              "multilanguage": false,
+              "index": false,
+              "position": "1col1",
+              "dependencies": []
             },
             {
               "fieldname": "URL",
@@ -395,7 +402,17 @@
               "text": "Bottom Info Dark"
             }
           ],
-          "advanced": false
+          "advanced": true,
+          "required": false,
+          "hidden": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": [
+            {
+              "fieldname": "HoverStyles",
+              "values": "Centered Icons,Icons Colors"
+            }
+          ]
         },
         {
           "fieldname": "NoBorders",

--- a/Porto-Image-Frames/data.json
+++ b/Porto-Image-Frames/data.json
@@ -1,39 +1,36 @@
 {
-  "Groups": [
-    {
-      "Item": "websites"
-    },
-    {
-      "Item": "logos"
-    },
-    {
-      "Item": "brands"
-    }
-  ],
   "Items": [
     {
+      "HoverStyles": "Default",
+      "DefaultStyles": "img-thumbnail d-inline-block",
       "Image": "",
       "ProjectTitle": "Some title1",
       "ProjectType": "Some type1",
-      "Group": "websites"
+      "GridWidth": "col-md-3"
     },
     {
+      "HoverStyles": "Default",
+      "DefaultStyles": "img-thumbnail d-inline-block",
       "Image": "",
       "ProjectTitle": "Some title2",
       "ProjectType": "Some type2",
-      "Group": "websites"
+      "GridWidth": "col-md-3"
     },
     {
+      "HoverStyles": "Default",
+      "DefaultStyles": "img-thumbnail d-inline-block",
       "Image": "",
       "ProjectTitle": "Some title3",
       "ProjectType": "Some type3",
-      "Group": "logos"
+      "GridWidth": "col-md-3"
     },
     {
+      "HoverStyles": "Default",
+      "DefaultStyles": "img-thumbnail d-inline-block",
       "Image": "",
       "ProjectTitle": "Some title4",
       "ProjectType": "Some type4",
-      "Group": "brands"
+      "GridWidth": "col-md-3"
     }
   ]
 }

--- a/Porto-Image-Frames/options.json
+++ b/Porto-Image-Frames/options.json
@@ -15,6 +15,7 @@
               "Centered Icons",
               "Icons Colors",
               "Centered Info",
+              "Hide Info Hover",
               "FadeIn",
               "Animation Style"
             ]
@@ -23,7 +24,6 @@
             "type": "select",
             "sort": false,
             "optionLabels": [
-              "rounded",
               "rounded-circle",
               "img-thumbnail d-inline-block"
             ]
@@ -105,7 +105,8 @@
             "items": {
               "fields": {
                 "Name": {
-                  "type": "text"
+                  "type": "text",
+                  "placeholder": "facebook"
                 },
                 "URL": {
                   "type": "text"
@@ -179,7 +180,13 @@
             "optionLabels": [
               "Bottom Info",
               "Bottom Info Dark"
-            ]
+            ],
+            "dependencies": {
+              "HoverStyles": [
+                "Centered Icons",
+                "Icons Colors"
+              ]
+            }
           },
           "NoBorders": {
             "type": "checkbox"

--- a/Porto-Image-Frames/schema.json
+++ b/Porto-Image-Frames/schema.json
@@ -18,6 +18,7 @@
               "Centered Icons",
               "Icons Colors",
               "thumb-info-centered-info",
+              "Hide Info Hover",
               "FadeIn",
               "Animation Style"
             ]
@@ -26,7 +27,6 @@
             "type": "string",
             "title": "Default Styles",
             "enum": [
-              "rounded",
               "rounded-circle",
               "img-thumbnail d-inline-block"
             ]
@@ -184,6 +184,9 @@
             "enum": [
               "thumb-info-bottom-info",
               "thumb-info-bottom-info thumb-info-bottom-info-dark"
+            ],
+            "dependencies": [
+              "HoverStyles"
             ]
           },
           "NoBorders": {


### PR DESCRIPTION
Porto Image Frames Shortcodes template(https://porto.mandeeps.com/shortcodes/shortcodes-2/image-frames):

- The "Group" dropdown does not serve any purpose
- There are no differences in Hover Styles between Default and Zoom
- In Default Styles there are no differences between rounded and rounded-circle
- Missing Centered Info and Hide Info Hover style
- Add dependencies to “Bottom” dropdown
