### PR TITLE
Fix OpenContent template for Porto Typography Shortcodes

### DIFF
--- a/Porto-Typography/Template.hbs
+++ b/Porto-Typography/Template.hbs
@@ -1,11 +1,11 @@
 {{#each Sections}}
-{{#equal Class "None"}}
+{{#equal Class "default"}}
   <{{Size}} class="mb-sm word-rotator-title">
      {{Text}}
      <span class="{{Color}}">{{TextWidthColor}}</span>
      <span class="alternative-font">{{AlternativeFont}}</span>
      {{OtherText}}
-  </span>
+  </{{Size}}>
  {{else}}
   <p class="{{Class}}">
      {{Text}}

--- a/Porto-Typography/builder.json
+++ b/Porto-Typography/builder.json
@@ -17,6 +17,10 @@
           "fieldtype": "select",
           "fieldoptions": [
             {
+              "value": "default",
+              "text": "Default"
+            },
+            {
               "value": "drop-caps",
               "text": "Drop Caps"
             },
@@ -25,6 +29,7 @@
               "text": "Drop Caps Style-2"
             }
           ],
+          "removeDefaultNone": true,
           "advanced": true,
           "required": false,
           "hidden": false,

--- a/Porto-Typography/data.json
+++ b/Porto-Typography/data.json
@@ -2,7 +2,7 @@
   "Sections": [
     {
       "Text": "Some text",
-      "Class": "None",
+      "Class": "Default",
       "AlternativeFont": "Alternative Font",
       "TextWidthColor": "Text Width Color",
       "Color": "text-primary",

--- a/Porto-Typography/options.json
+++ b/Porto-Typography/options.json
@@ -10,7 +10,8 @@
           "Class": {
             "type": "select",
             "sort": false,
-            "optionLabels": ["Drop Caps", "Drop Caps Style-2"]
+            "optionLabels": ["Default", "Drop Caps", "Drop Caps Style-2"],
+            "removeDefaultNone": true
           },
           "AlternativeFont": {
             "type": "text"

--- a/Porto-Typography/schema.json
+++ b/Porto-Typography/schema.json
@@ -14,7 +14,8 @@
           "Class": {
             "type": "string",
             "title": "Class",
-            "enum": ["drop-caps", "drop-caps drop-caps-style-2"]
+            "enum": ["default", "drop-caps", "drop-caps drop-caps-style-2"],
+            "removeDefaultNone": true
           },
           "AlternativeFont": {
             "type": "string",


### PR DESCRIPTION
Porto Typography Shortcodes template (https://porto.mandeeps.com/shortcodes/shortcodes-2/typography)
• Problems with the None value in the Class dropdown
