### PR TITLE
Fix OpenContent template for Porto Posts Shortcodes

### DIFF
--- a/Porto-Posts/Template.hbs
+++ b/Porto-Posts/Template.hbs
@@ -56,39 +56,41 @@
 {{/equal}}
 {{#equal Style "Church"}}
   {{#equal ChurchsStyle "info"}}
-    {{#each Churchs}}
-      <div class="church">
-        <div
-          class="thumb-info custom-thumb-info custom-box-shadow thumb-info-hide-wrapper-bg custom-sm-margin-bottom-1"
-        >
-          <span class="thumb-info-wrapper">
-            <a href="#">
-              <img alt="Image" src="{{Image}}" class="img-fluid" />
-            </a>
-          </span>
-          <div class="thumb-info-caption">
-            <div class="custom-event-infos">
-              <ul>
-                <li><em class="fas fa-clock"></em> {{Time}}</li>
-                <li class="text-uppercase"><em
-                    class="fas fa-map-marker-alt"
-                  ></em>
-                  {{Location}}</li>
-              </ul>
-            </div>
+    <div class="row">
+      {{#each Churchs}}
+        <div class="church {{@root.GridWidth}}">
+          <div
+            class="thumb-info custom-thumb-info custom-box-shadow thumb-info-hide-wrapper-bg custom-sm-margin-bottom-1"
+          >
+            <span class="thumb-info-wrapper">
+              <a href="#">
+                <img alt="Image" src="{{Image}}" class="img-fluid" />
+              </a>
+            </span>
+            <div class="thumb-info-caption">
+              <div class="custom-event-infos">
+                <ul>
+                  <li><em class="fas fa-clock"></em> {{Time}}</li>
+                  <li class="text-uppercase"><em
+                      class="fas fa-map-marker-alt"
+                    ></em>
+                    {{Location}}</li>
+                </ul>
+              </div>
 
-            <div class="thumb-info-caption-text">
-              <h4 class="font-weight-bold mb-sm"><a
-                  class="text-color-dark"
-                  href="#"
-                >{{Title}} </a></h4>
+              <div class="thumb-info-caption-text">
+                <h4 class="font-weight-bold mb-sm"><a
+                    class="text-color-dark"
+                    href="#"
+                  >{{Title}} </a></h4>
 
-              <p>{{Content}}</p>
+                <p>{{Content}}</p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    {{/each}}
+      {{/each}}
+    </div>
   {{/equal}}
   {{#equal ChurchsStyle "inverted"}}
     {{#each Churchs}}

--- a/Porto-Posts/builder.json
+++ b/Porto-Posts/builder.json
@@ -190,6 +190,72 @@
       ]
     },
     {
+      "fieldname": "GridWidth",
+      "title": "GridWidth",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "col-md-1",
+          "text": "col-md-1"
+        },
+        {
+          "value": "col-md-2",
+          "text": "col-md-2"
+        },
+        {
+          "value": "col-md-3",
+          "text": "col-md-3"
+        },
+        {
+          "value": "col-md-4",
+          "text": "col-md-4"
+        },
+        {
+          "value": "col-md-5",
+          "text": "col-md-5"
+        },
+        {
+          "value": "col-md-6",
+          "text": "col-md-6"
+        },
+        {
+          "value": "col-md-7",
+          "text": "col-md-7"
+        },
+        {
+          "value": "col-md-8",
+          "text": "col-md-8"
+        },
+        {
+          "value": "col-md-9",
+          "text": "col-md-9"
+        },
+        {
+          "value": "col-md-10",
+          "text": "col-md-10"
+        },
+        {
+          "value": "col-md-11",
+          "text": "col-md-11"
+        },
+        {
+          "value": "col-md-12",
+          "text": "col-md-12"
+        }
+      ],
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "ChurchsStyle",
+          "values": "info"
+        }
+      ]
+    },
+    {
       "fieldname": "Churchs",
       "title": "Churchs",
       "fieldtype": "array",

--- a/Porto-Posts/options.json
+++ b/Porto-Posts/options.json
@@ -100,6 +100,29 @@
         ]
       }
     },
+    "GridWidth": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "col-md-1",
+        "col-md-2",
+        "col-md-3",
+        "col-md-4",
+        "col-md-5",
+        "col-md-6",
+        "col-md-7",
+        "col-md-8",
+        "col-md-9",
+        "col-md-10",
+        "col-md-11",
+        "col-md-12"
+      ],
+      "dependencies": {
+        "ChurchsStyle": [
+          "info"
+        ]
+      }
+    },
     "Churchs": {
       "type": "array",
       "dependencies": {

--- a/Porto-Posts/schema.json
+++ b/Porto-Posts/schema.json
@@ -108,6 +108,27 @@
         "Style"
       ]
     },
+    "GridWidth": {
+      "type": "string",
+      "title": "GridWidth",
+      "enum": [
+        "col-md-1",
+        "col-md-2",
+        "col-md-3",
+        "col-md-4",
+        "col-md-5",
+        "col-md-6",
+        "col-md-7",
+        "col-md-8",
+        "col-md-9",
+        "col-md-10",
+        "col-md-11",
+        "col-md-12"
+      ],
+      "dependencies": [
+        "ChurchsStyle"
+      ]
+    },
     "Churchs": {
       "type": "array",
       "title": "Churchs",

--- a/Porto-Posts/view.json
+++ b/Porto-Posts/view.json
@@ -6,6 +6,7 @@
       "Style": "#pos_1_1",
       "Posts": "#pos_1_1",
       "ChurchsStyle": "#pos_1_1",
+      "GridWidth": "#pos_1_1",
       "Churchs": "#pos_1_1"
     }
   }


### PR DESCRIPTION
Porto Posts Shortcodes template(https://porto.mandeeps.com/shortcodes/shortcodes-4/posts). 

When "Churchs Style" is equal to "info" the container was too big if it was put in CONTENTPANE for example.
I added a grid system to readjust it to the client's desire and not have to move it to another container.

Example
![Test Porto Templates Post ](https://user-images.githubusercontent.com/48692645/216160836-ccf25220-915b-489a-bfbd-072c0f5c4e79.jpg)


Fixed up
![ Porto Post Templates](https://user-images.githubusercontent.com/48692645/216160496-06c1f95f-1ca3-4930-943f-e8d899a86f12.jpg)